### PR TITLE
Use absolute value to ensure correct handling of negative hashcodes

### DIFF
--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/PartitionedRemoteServiceMethod.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/PartitionedRemoteServiceMethod.java
@@ -225,7 +225,7 @@ public class PartitionedRemoteServiceMethod implements RemoteServiceMethod {
 
 		public void addElement(Object element) {
 			Object routingKey = router.getRoutingKey(element);
-			int targetPartition = routingKey.hashCode() % requests.length;
+			int targetPartition = safeAbsoluteValue(routingKey.hashCode()) % requests.length;
 			RoutedServiceInvocationRequestBuilder invocationRequestBuilderForPartition = this.requests[targetPartition];
 			if (invocationRequestBuilderForPartition == null) {
 				invocationRequestBuilderForPartition = new RoutedServiceInvocationRequestBuilder(newCollectionInstance(), targetPartition);
@@ -233,6 +233,10 @@ public class PartitionedRemoteServiceMethod implements RemoteServiceMethod {
 				
 			}
 			invocationRequestBuilderForPartition.addKey(element);
+		}
+
+		private int safeAbsoluteValue(int hashcode){
+			return hashcode == Integer.MIN_VALUE ? Integer.MAX_VALUE : Math.abs(hashcode);
 		}
 
 	}


### PR DESCRIPTION
Partitioned Routing does not work for objects with negative hashCodes.