### PR TITLE
Add support for RxJava Single and Completable return types.

### DIFF
--- a/astrix-context/src/main/java/com/avanza/astrix/beans/rx/CompletableTypeHandler.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/rx/CompletableTypeHandler.java
@@ -1,0 +1,59 @@
+package com.avanza.astrix.beans.rx;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import com.avanza.astrix.beans.core.ReactiveExecutionListener;
+import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
+import rx.Completable;
+
+/**
+ * Created by Daniel Bergholm
+ */
+public class CompletableTypeHandler implements ReactiveTypeHandlerPlugin<Completable> {
+	@Override
+	public void subscribe(ReactiveExecutionListener listener, Completable reactiveType) {
+		reactiveType.subscribe(listener::onError, () -> listener.onResult(null));
+	}
+
+	@Override
+	public void completeExceptionally(Throwable error, Completable reactiveType) {
+		DelayedCompletable.class.cast(reactiveType).completableFuture.completeExceptionally(error);
+	}
+
+	@Override
+	public void complete(Object result, Completable reactiveType) {
+		DelayedCompletable.class.cast(reactiveType).completableFuture.complete(null);
+	}
+
+	@Override
+	public Completable newReactiveType() {
+		return new DelayedCompletable();
+	}
+
+	@Override
+	public Class<Completable> reactiveTypeHandled() {
+		return Completable.class;
+	}
+
+	private static class DelayedCompletable extends Completable {
+		private final CompletableFuture<Void> completableFuture;
+
+		private DelayedCompletable(CompletableFuture<Void> completableFuture) {
+			super(subscriber -> completableFuture.whenComplete((value, throwable) -> {
+				if (throwable == null) {
+					subscriber.onCompleted();
+				} else {
+					Throwable exception = throwable instanceof CompletionException ? throwable.getCause() : throwable;
+					subscriber.onError(exception);
+				}
+			}));
+			this.completableFuture = completableFuture;
+		}
+
+		public DelayedCompletable() {
+			this(new CompletableFuture<>());
+		}
+
+	}
+}

--- a/astrix-context/src/main/java/com/avanza/astrix/beans/rx/CompletableTypeHandler.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/rx/CompletableTypeHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.astrix.beans.rx;
 
 import java.util.concurrent.CompletableFuture;
@@ -7,9 +22,6 @@ import com.avanza.astrix.beans.core.ReactiveExecutionListener;
 import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
 import rx.Completable;
 
-/**
- * Created by Daniel Bergholm
- */
 public class CompletableTypeHandler implements ReactiveTypeHandlerPlugin<Completable> {
 	@Override
 	public void subscribe(ReactiveExecutionListener listener, Completable reactiveType) {

--- a/astrix-context/src/main/java/com/avanza/astrix/beans/rx/SingleTypeHandler.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/rx/SingleTypeHandler.java
@@ -1,0 +1,70 @@
+package com.avanza.astrix.beans.rx;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import com.avanza.astrix.beans.core.ReactiveExecutionListener;
+import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
+import rx.Single;
+import rx.subscriptions.Subscriptions;
+
+/**
+ * Created by Daniel Bergholm
+ */
+public class SingleTypeHandler implements ReactiveTypeHandlerPlugin<Single<Object>> {
+	@Override
+	public void subscribe(ReactiveExecutionListener listener, Single<Object> reactiveType) {
+		reactiveType.subscribe(listener::onResult, listener::onError);
+	}
+
+	@Override
+	public void completeExceptionally(Throwable error, Single<Object> reactiveType) {
+		CompletableSingle.class.cast(reactiveType).completeExceptionally(error);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void complete(Object result, Single<Object> reactiveType) {
+		CompletableSingle.class.cast(reactiveType).complete(result);
+	}
+
+	@Override
+	public Single<Object> newReactiveType() {
+		return new CompletableSingle<>();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Class<Single<Object>> reactiveTypeHandled() {
+		Class<?> type = Single.class;
+		return (Class<Single<Object>>) type;
+	}
+
+	private static class CompletableSingle<T> extends Single<T> {
+		private final CompletableFuture<T> completableFuture;
+
+		private CompletableSingle(CompletableFuture<T> completableFuture) {
+			super(subscriber -> subscriber.add(Subscriptions.from(completableFuture.whenComplete((value, throwable) -> {
+				if (throwable == null) {
+					subscriber.onSuccess(value);
+				} else {
+					Throwable exception = throwable instanceof CompletionException ? throwable.getCause() : throwable;
+					subscriber.onError(exception);
+				}
+			}))));
+			this.completableFuture = completableFuture;
+		}
+
+		public CompletableSingle() {
+			this(new CompletableFuture<>());
+		}
+
+		public void complete(T value) {
+			completableFuture.complete(value);
+		}
+
+		public void completeExceptionally(Throwable error) {
+			completableFuture.completeExceptionally(error);
+		}
+	}
+}

--- a/astrix-context/src/main/java/com/avanza/astrix/beans/rx/SingleTypeHandler.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/rx/SingleTypeHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.astrix.beans.rx;
 
 import java.util.concurrent.CompletableFuture;
@@ -8,9 +23,6 @@ import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
 import rx.Single;
 import rx.subscriptions.Subscriptions;
 
-/**
- * Created by Daniel Bergholm
- */
 public class SingleTypeHandler implements ReactiveTypeHandlerPlugin<Single<Object>> {
 	@Override
 	public void subscribe(ReactiveExecutionListener listener, Single<Object> reactiveType) {

--- a/astrix-context/src/main/java/com/avanza/astrix/beans/rx/SingleTypeHandler.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/rx/SingleTypeHandler.java
@@ -19,18 +19,18 @@ public class SingleTypeHandler implements ReactiveTypeHandlerPlugin<Single<Objec
 
 	@Override
 	public void completeExceptionally(Throwable error, Single<Object> reactiveType) {
-		CompletableSingle.class.cast(reactiveType).completeExceptionally(error);
+		DelayedSingle.class.cast(reactiveType).completableFuture.completeExceptionally(error);
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public void complete(Object result, Single<Object> reactiveType) {
-		CompletableSingle.class.cast(reactiveType).complete(result);
+		DelayedSingle.class.cast(reactiveType).completableFuture.complete(result);
 	}
 
 	@Override
 	public Single<Object> newReactiveType() {
-		return new CompletableSingle<>();
+		return new DelayedSingle<>();
 	}
 
 	@Override
@@ -40,10 +40,10 @@ public class SingleTypeHandler implements ReactiveTypeHandlerPlugin<Single<Objec
 		return (Class<Single<Object>>) type;
 	}
 
-	private static class CompletableSingle<T> extends Single<T> {
+	private static class DelayedSingle<T> extends Single<T> {
 		private final CompletableFuture<T> completableFuture;
 
-		private CompletableSingle(CompletableFuture<T> completableFuture) {
+		private DelayedSingle(CompletableFuture<T> completableFuture) {
 			super(subscriber -> subscriber.add(Subscriptions.from(completableFuture.whenComplete((value, throwable) -> {
 				if (throwable == null) {
 					subscriber.onSuccess(value);
@@ -55,16 +55,9 @@ public class SingleTypeHandler implements ReactiveTypeHandlerPlugin<Single<Objec
 			this.completableFuture = completableFuture;
 		}
 
-		public CompletableSingle() {
+		public DelayedSingle() {
 			this(new CompletableFuture<>());
 		}
 
-		public void complete(T value) {
-			completableFuture.complete(value);
-		}
-
-		public void completeExceptionally(Throwable error) {
-			completableFuture.completeExceptionally(error);
-		}
 	}
 }

--- a/astrix-contracts/src/main/java/com/avanza/astrix/contracts/ReactiveTypeHandlerContract.java
+++ b/astrix-contracts/src/main/java/com/avanza/astrix/contracts/ReactiveTypeHandlerContract.java
@@ -15,38 +15,40 @@
  */
 package com.avanza.astrix.contracts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import com.avanza.astrix.beans.core.ReactiveExecutionListener;
 import com.avanza.astrix.beans.core.ReactiveTypeConverter;
 import com.avanza.astrix.beans.core.ReactiveTypeConverterImpl;
 import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
-
+import org.junit.Before;
+import org.junit.Test;
 import rx.Observable;
 import rx.Subscriber;
 
 public abstract class ReactiveTypeHandlerContract<T> {
-	
+
+
 	private ReactiveTypeConverter reactiveTypeConverter;
 	private ReactiveTypeHandlerPlugin<T> reactiveTypeHandler;
-	
+	private String value;
+
 	@Before
 	public void setup() {
+		value = valueToTest();
+
 		reactiveTypeHandler = newReactiveTypeHandler();
 		reactiveTypeConverter = new ReactiveTypeConverterImpl(Arrays.asList(reactiveTypeHandler));
 	}
-	
+
+	protected String valueToTest() {
+		return "foo";
+	}
+
 	protected abstract ReactiveTypeHandlerPlugin<T> newReactiveTypeHandler();
 
 	@Test(timeout=2000)
@@ -60,9 +62,9 @@ public abstract class ReactiveTypeHandlerContract<T> {
 		assertNull(resultSpy.error);
 		assertNull(resultSpy.lastElement);
 		
-		reactiveTypeHandler.complete("foo", reactiveType); // Complete reactive execution
+		reactiveTypeHandler.complete(value, reactiveType); // Complete reactive execution
 		assertTrue(resultSpy.isDone());
-		assertEquals("foo", resultSpy.lastElement);
+		assertEquals(value, resultSpy.lastElement);
 		assertNull(resultSpy.error);
 	}
 	
@@ -70,13 +72,13 @@ public abstract class ReactiveTypeHandlerContract<T> {
 	public final void reactiveTypeListenerIsNotifiedSynchronouslyIfReactiveExecutionAlreadyCompleted() throws Exception {
 		T reactiveType = reactiveTypeHandler.newReactiveType();
 
-		reactiveTypeHandler.complete("foo", reactiveType); // Completes reactive execution
+		reactiveTypeHandler.complete(value, reactiveType); // Completes reactive execution
 		
 		ReactiveResultSpy resultSpy = new ReactiveResultSpy();
 		reactiveTypeHandler.subscribe(resultSpy, reactiveType); // Subscribe after execution completes
 		
 		assertTrue(resultSpy.isDone());
-		assertEquals("foo", resultSpy.lastElement);
+		assertEquals(value, resultSpy.lastElement);
 		assertNull(resultSpy.error);
 	}
 	
@@ -91,10 +93,10 @@ public abstract class ReactiveTypeHandlerContract<T> {
 		
 		assertFalse(reactiveResultListener.isDone());
 		
-		reactiveTypeHandler.complete("foo", reactiveType);
+		reactiveTypeHandler.complete(value, reactiveType);
 		
 		assertTrue(reactiveResultListener.isDone());
-		assertEquals("foo", reactiveResultListener.lastElement);
+		assertEquals(value, reactiveResultListener.lastElement);
 		assertNull(reactiveResultListener.error);
 	}
 	
@@ -103,7 +105,7 @@ public abstract class ReactiveTypeHandlerContract<T> {
 		AtomicInteger sourceSubscriptionCount = new AtomicInteger(0);
 		Observable<Object> emitsFoo = Observable.create((s) -> {
 			sourceSubscriptionCount.incrementAndGet();
-			s.onNext("foo");
+			s.onNext(value);
 			s.onCompleted();
 		});
 		
@@ -114,7 +116,7 @@ public abstract class ReactiveTypeHandlerContract<T> {
 		ReactiveResultSpy resultSpy = new ReactiveResultSpy();
 		reactiveTypeHandler.subscribe(resultSpy, reactiveType);
 		
-		assertEquals("foo", resultSpy.lastElement);
+		assertEquals(value, resultSpy.lastElement);
 	}
 	
 	@Test
@@ -122,7 +124,7 @@ public abstract class ReactiveTypeHandlerContract<T> {
 		AtomicInteger sourceSubscriptionCount = new AtomicInteger(0);
 		Observable<Object> emitsFoo = Observable.create((s) -> {
 			sourceSubscriptionCount.incrementAndGet();
-			s.onNext("foo");
+			s.onNext(value);
 			s.onCompleted();
 		});
 		
@@ -134,7 +136,7 @@ public abstract class ReactiveTypeHandlerContract<T> {
 		ReactiveResultSpy resultSpy = new ReactiveResultSpy();
 		reactiveTypeHandler.subscribe(resultSpy, reactiveType);
 		
-		assertEquals("foo", resultSpy.lastElement);
+		assertEquals(value, resultSpy.lastElement);
 	}
 	
 	@Test
@@ -147,11 +149,11 @@ public abstract class ReactiveTypeHandlerContract<T> {
 		assertNull(resultSpy.error);
 		assertNull(resultSpy.lastElement);
 		
-		reactiveTypeHandler.completeExceptionally(new RuntimeException("foo"), reactiveType); // Complete reactive execution
+		reactiveTypeHandler.completeExceptionally(new RuntimeException(value), reactiveType); // Complete reactive execution
 		assertTrue(resultSpy.isDone());
 		assertNull(resultSpy.lastElement);
 		assertNotNull(resultSpy.error);
-		assertEquals("foo", resultSpy.error.getMessage());
+		assertEquals(value, resultSpy.error.getMessage());
 	}
 
 	private T toCustomReactiveType(Observable<Object> emitsFoo) {

--- a/astrix-contracts/src/test/java/com/avanza/astrix/contracts/CompletableTypeHandlerTest.java
+++ b/astrix-contracts/src/test/java/com/avanza/astrix/contracts/CompletableTypeHandlerTest.java
@@ -1,0 +1,20 @@
+package com.avanza.astrix.contracts;
+
+import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
+import com.avanza.astrix.beans.rx.CompletableTypeHandler;
+import rx.Completable;
+
+/**
+ * Created by Daniel Bergholm
+ */
+public class CompletableTypeHandlerTest extends ReactiveTypeHandlerContract<Completable> {
+	@Override
+	protected ReactiveTypeHandlerPlugin<Completable> newReactiveTypeHandler() {
+		return new CompletableTypeHandler();
+	}
+
+	@Override
+	protected String valueToTest() {
+		return null;
+	}
+}

--- a/astrix-contracts/src/test/java/com/avanza/astrix/contracts/CompletableTypeHandlerTest.java
+++ b/astrix-contracts/src/test/java/com/avanza/astrix/contracts/CompletableTypeHandlerTest.java
@@ -1,12 +1,24 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.astrix.contracts;
 
 import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
 import com.avanza.astrix.beans.rx.CompletableTypeHandler;
 import rx.Completable;
 
-/**
- * Created by Daniel Bergholm
- */
 public class CompletableTypeHandlerTest extends ReactiveTypeHandlerContract<Completable> {
 	@Override
 	protected ReactiveTypeHandlerPlugin<Completable> newReactiveTypeHandler() {

--- a/astrix-contracts/src/test/java/com/avanza/astrix/contracts/SingleTypeHandlerTest.java
+++ b/astrix-contracts/src/test/java/com/avanza/astrix/contracts/SingleTypeHandlerTest.java
@@ -1,0 +1,15 @@
+package com.avanza.astrix.contracts;
+
+import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
+import com.avanza.astrix.beans.rx.SingleTypeHandler;
+import rx.Single;
+
+/**
+ * Created by Daniel Bergholm
+ */
+public class SingleTypeHandlerTest extends ReactiveTypeHandlerContract<Single<Object>> {
+	@Override
+	protected ReactiveTypeHandlerPlugin<Single<Object>> newReactiveTypeHandler() {
+		return new SingleTypeHandler();
+	}
+}

--- a/astrix-contracts/src/test/java/com/avanza/astrix/contracts/SingleTypeHandlerTest.java
+++ b/astrix-contracts/src/test/java/com/avanza/astrix/contracts/SingleTypeHandlerTest.java
@@ -1,12 +1,24 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.astrix.contracts;
 
 import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
 import com.avanza.astrix.beans.rx.SingleTypeHandler;
 import rx.Single;
 
-/**
- * Created by Daniel Bergholm
- */
 public class SingleTypeHandlerTest extends ReactiveTypeHandlerContract<Single<Object>> {
 	@Override
 	protected ReactiveTypeHandlerPlugin<Single<Object>> newReactiveTypeHandler() {

--- a/pom.xml
+++ b/pom.xml
@@ -142,8 +142,8 @@
 		<spring.groupId>org.springframework</spring.groupId>
 		<slf4j.version>1.7.10</slf4j.version>
 		<gigaspaces.version>10.1.1-12800-RELEASE</gigaspaces.version>
-		<rxjava.version>1.0.14</rxjava.version>
-		<hystrix.version>1.4.20</hystrix.version>
+		<rxjava.version>1.1.1</rxjava.version>
+		<hystrix.version>1.4.24</hystrix.version>
 		<archaius.version>0.4.1</archaius.version>
 		<jackson1.version>1.9.12</jackson1.version>
 		<guava.version>14.0.1</guava.version>


### PR DESCRIPTION
The "Single" return type is like an Observable that only emits once. It is useful for asynchronous methods that do not stream their results. See http://reactivex.io/documentation/single.html

The "Completable" return type is like an empty Observable. It calls onComplete or onError, but never emits any value. It is useful for asynchronous void methods. See https://github.com/ReactiveX/RxJava/releases/tag/v1.1.1