### PR TITLE
Adds unit test for `AstrixServiceRegistryImpl::deregister`

### DIFF
--- a/astrix-context/src/main/java/com/avanza/astrix/context/AstrixConfigurer.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/context/AstrixConfigurer.java
@@ -374,7 +374,7 @@ public class AstrixConfigurer {
 	 * allowed to invoke non-versioned services within the same subsystem. Attempting
 	 * to invoke a non-versioned service in another subsystem will throw an IllegalSubsystemException. <p>
 	 * 
-	 * @param string
+	 * @param subsystem
 	 * @return 
 	 */
 	public AstrixConfigurer setSubsystem(String subsystem) {

--- a/astrix-core/src/main/java/com/avanza/astrix/core/AstrixRouting.java
+++ b/astrix-core/src/main/java/com/avanza/astrix/core/AstrixRouting.java
@@ -34,7 +34,7 @@ public @interface AstrixRouting {
 	
 	/**
      * Optional method name. If set then the given method will be called on the argument holding this 
-     * annotation to resolve the rouging value. The method must have zero arguments.
+     * annotation to resolve the routing value. The method must have zero arguments.
      */
     String value() default "";
 }

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -4,6 +4,6 @@
     <title>Astrix Framework API</title>
   </head>
   <body>
-    The Astrix Framework simplifies development and maintainence of microservices.
+    The Astrix Framework simplifies development and maintenance of microservices.
   </body>
 </html>


### PR DESCRIPTION
* Adds unit test for method `AstrixServiceRegistryImpl::deregister` and
  `getServiceProviderKey`.
* Before this commit, JaCoCo reports 74% line code-coverage from unit tests on
  `AstrixServiceRegistryImpl`. After this commit, line code-coverage is 97%.
* Fixes minor spelling corrections.