### PR TITLE
TP-270: Bugfix: Initialize `ClusteredProxyCacheImpl` with known classes (gs14)

### DIFF
--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/ClusteredProxyCacheImpl.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/ClusteredProxyCacheImpl.java
@@ -15,8 +15,7 @@
  */
 package com.avanza.astrix.gs;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -29,9 +28,10 @@ import org.openspaces.core.space.UrlSpaceConfigurer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.avanza.astrix.beans.async.ContextPropagation;
-import com.avanza.astrix.beans.async.ContextPropagator;
 import com.avanza.astrix.beans.core.AstrixConfigAware;
 import com.avanza.astrix.beans.service.ServiceProperties;
+import com.avanza.astrix.beans.tracing.AstrixTraceProvider;
+import com.avanza.astrix.beans.tracing.DefaultTraceProvider;
 import com.avanza.astrix.config.DynamicConfig;
 import com.avanza.astrix.modules.AstrixInject;
 import com.avanza.astrix.modules.KeyLock;
@@ -53,16 +53,18 @@ public class ClusteredProxyCacheImpl implements AstrixConfigAware, ClusteredProx
 	private ContextPropagation contextPropagation;
 
 	/**
-	 * @deprecated please use {@link #ClusteredProxyCacheImpl(List)}
+	 * @deprecated please use {@link #ClusteredProxyCacheImpl(AstrixTraceProvider)}
 	 */
 	@Deprecated
 	public ClusteredProxyCacheImpl() {
-		this(Collections.emptyList());
+		this(new DefaultTraceProvider());
 	}
 
 	@AstrixInject
-	public ClusteredProxyCacheImpl(List<ContextPropagator> contextPropagators) {
-		this.contextPropagation = ContextPropagation.create(contextPropagators);
+	public ClusteredProxyCacheImpl(AstrixTraceProvider astrixTraceProvider) {
+		this.contextPropagation = ContextPropagation.create(
+				Objects.requireNonNull(astrixTraceProvider).getContextPropagators()
+		);
 	}
 
 	/**

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/GsModule.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/GsModule.java
@@ -15,10 +15,10 @@
  */
 package com.avanza.astrix.gs;
 
-import com.avanza.astrix.beans.async.ContextPropagator;
 import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
 import com.avanza.astrix.beans.ft.BeanFaultToleranceFactory;
 import com.avanza.astrix.beans.service.ServiceComponent;
+import com.avanza.astrix.beans.tracing.AstrixTraceProvider;
 import com.avanza.astrix.context.AstrixContextPlugin;
 import com.avanza.astrix.context.AstrixStrategiesConfig;
 import com.avanza.astrix.modules.ModuleContext;
@@ -40,7 +40,7 @@ public class GsModule implements AstrixContextPlugin {
 		
 		moduleContext.importType(AstrixSpringContext.class);
 		moduleContext.importType(BeanFaultToleranceFactory.class);
-		moduleContext.importType(ContextPropagator.class);
+		moduleContext.importType(AstrixTraceProvider.class);
 		
 		moduleContext.export(ServiceComponent.class);
 		moduleContext.export(ClusteredProxyBinder.class);

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/SpaceTaskDispatcher.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/SpaceTaskDispatcher.java
@@ -87,7 +87,7 @@ public final class SpaceTaskDispatcher {
 											 new LinkedBlockingQueue<Runnable>(),
 											 new NamedThreadFactory(String.format("SpaceTaskDispatcher[%s]", spaceInstanceName)));
 		poolSize.addListener(newValue -> {
-			log.info(String.format("Changing pool-size for SpaceTaskDistpatcher. space=%s newSize=%s, oldSize=%s", 
+			log.info(String.format("Changing pool-size for SpaceTaskDispatcher. space=%s newSize=%s, oldSize=%s",
 									SpaceTaskDispatcher.this.gigaSpace.getName(), 
 									newValue, executorService.getMaximumPoolSize()));
 			executorService.setCorePoolSize(newValue);


### PR DESCRIPTION
* The class `ClusteredProxyCacheImpl` is initialized by the Astrix autowiring framework, as specified in `GsModule`.
* Therefore, the components used in the constructor must be well-defined.
* This commit updates a constructor parameter from `List<>` to the more specific `AstrixTraceProvider` so that the type of peremeter is well-defined.
* Reason for updating is to ensure that the autowired object is not an empty list (which it was before), but always the values defined by the `AstrixTraceProvider`.