### PR TITLE
TP-349: Allow building on Java11

### DIFF
--- a/astrix-config/pom.xml
+++ b/astrix-config/pom.xml
@@ -13,6 +13,10 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/astrix-context/pom.xml
+++ b/astrix-context/pom.xml
@@ -37,12 +37,6 @@
 			<groupId>io.reactivex</groupId>
 			<artifactId>rxjava</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.kohsuke.metainf-services</groupId>
-			<artifactId>metainf-services</artifactId>
-			<version>1.1</version>
-			<optional>true</optional>
-		</dependency>
 
 		<dependency>
 			<groupId>org.reflections</groupId>

--- a/astrix-context/src/main/java/com/avanza/astrix/context/AstrixConfigurer.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/context/AstrixConfigurer.java
@@ -103,7 +103,7 @@ public class AstrixConfigurer {
 	
 	private ApiProviders astrixApiProviders;
 	private final Collection<StandardFactoryBean<?>> standaloneFactories = new LinkedList<>();
-	private final List<com.avanza.astrix.modules.Module> customModules = new ArrayList<>();
+	private final List<Module> customModules = new ArrayList<>();
 	private final Map<Class<?>, StrategyProvider<?>> strategyProviderByType = new HashMap<>();
 	private final MapConfigSource settings = new MapConfigSource();
 	
@@ -450,7 +450,7 @@ public class AstrixConfigurer {
 		set(beanSetting.nameFor(beanKey), value);
 	}
 
-	void registerModule(com.avanza.astrix.modules.Module module) {
+	void registerModule(Module module) {
 		this.customModules.add(module);
 	}
 

--- a/astrix-context/src/main/java/com/avanza/astrix/context/AstrixConfigurer.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/context/AstrixConfigurer.java
@@ -15,10 +15,6 @@
  */
 package com.avanza.astrix.context;
 
-import java.lang.annotation.Annotation;
-import java.util.*;
-import java.util.stream.Stream;
-
 import com.avanza.astrix.beans.api.ApiProviderBeanPublisherModule;
 import com.avanza.astrix.beans.config.AstrixConfig;
 import com.avanza.astrix.beans.config.AstrixConfigModule;
@@ -33,8 +29,16 @@ import com.avanza.astrix.beans.core.AstrixConfigAware;
 import com.avanza.astrix.beans.core.AstrixSettings;
 import com.avanza.astrix.beans.factory.BeanFactoryModule;
 import com.avanza.astrix.beans.factory.StandardFactoryBean;
-import com.avanza.astrix.beans.ft.*;
-import com.avanza.astrix.beans.publish.*;
+import com.avanza.astrix.beans.ft.BeanFaultToleranceFactorySpi;
+import com.avanza.astrix.beans.ft.DefaultHystrixCommandNamingStrategy;
+import com.avanza.astrix.beans.ft.FaultToleranceModule;
+import com.avanza.astrix.beans.ft.HystrixCommandNamingStrategy;
+import com.avanza.astrix.beans.ft.NoFaultTolerance;
+import com.avanza.astrix.beans.publish.ApiProviderClass;
+import com.avanza.astrix.beans.publish.ApiProviderPlugins;
+import com.avanza.astrix.beans.publish.ApiProviders;
+import com.avanza.astrix.beans.publish.BeanPublisherPlugin;
+import com.avanza.astrix.beans.publish.BeansPublishModule;
 import com.avanza.astrix.beans.registry.AstrixServiceRegistryLibraryProvider;
 import com.avanza.astrix.beans.registry.AstrixServiceRegistryServiceProvider;
 import com.avanza.astrix.beans.registry.ServiceRegistryDiscoveryModule;
@@ -42,14 +46,25 @@ import com.avanza.astrix.beans.service.DirectComponentModule;
 import com.avanza.astrix.beans.service.ServiceModule;
 import com.avanza.astrix.beans.tracing.AstrixTraceProvider;
 import com.avanza.astrix.beans.tracing.DefaultTraceProvider;
-import com.avanza.astrix.config.*;
+import com.avanza.astrix.config.DynamicConfig;
+import com.avanza.astrix.config.LongSetting;
+import com.avanza.astrix.config.MapConfigSource;
+import com.avanza.astrix.config.PropertiesConfigSource;
+import com.avanza.astrix.config.Setting;
+import com.avanza.astrix.config.SystemPropertiesConfigSource;
 import com.avanza.astrix.context.mbeans.AstrixMBeanModule;
 import com.avanza.astrix.context.mbeans.MBeanServerFacade;
 import com.avanza.astrix.context.mbeans.PlatformMBeanServer;
 import com.avanza.astrix.context.metrics.DefaultMetricSpi;
 import com.avanza.astrix.context.metrics.MetricsModule;
 import com.avanza.astrix.context.metrics.MetricsSpi;
-import com.avanza.astrix.modules.*;
+import com.avanza.astrix.modules.Module;
+import com.avanza.astrix.modules.ModuleContext;
+import com.avanza.astrix.modules.ModuleInstancePostProcessor;
+import com.avanza.astrix.modules.Modules;
+import com.avanza.astrix.modules.ModulesConfigurer;
+import com.avanza.astrix.modules.StrategyContextPreparer;
+import com.avanza.astrix.modules.StrategyProvider;
 import com.avanza.astrix.provider.core.AstrixApiProvider;
 import com.avanza.astrix.provider.core.AstrixExcludedByProfile;
 import com.avanza.astrix.provider.core.AstrixIncludedByProfile;
@@ -60,6 +75,20 @@ import com.avanza.astrix.versioning.core.ObjectSerializerModule;
 import com.avanza.astrix.versioning.jackson2.Jackson2SerializerModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Stream;
 /**
  * Used to configure and create an {@link AstrixContext}. <p>
  * 
@@ -74,7 +103,7 @@ public class AstrixConfigurer {
 	
 	private ApiProviders astrixApiProviders;
 	private final Collection<StandardFactoryBean<?>> standaloneFactories = new LinkedList<>();
-	private final List<Module> customModules = new ArrayList<>();
+	private final List<com.avanza.astrix.modules.Module> customModules = new ArrayList<>();
 	private final Map<Class<?>, StrategyProvider<?>> strategyProviderByType = new HashMap<>();
 	private final MapConfigSource settings = new MapConfigSource();
 	
@@ -421,7 +450,7 @@ public class AstrixConfigurer {
 		set(beanSetting.nameFor(beanKey), value);
 	}
 
-	void registerModule(Module module) {
+	void registerModule(com.avanza.astrix.modules.Module module) {
 		this.customModules.add(module);
 	}
 

--- a/astrix-fault-tolerance/pom.xml
+++ b/astrix-fault-tolerance/pom.xml
@@ -52,11 +52,5 @@
 			<artifactId>slf4j-log4j12</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.kohsuke.metainf-services</groupId>
-			<artifactId>metainf-services</artifactId>
-			<version>1.1</version>
-			<optional>true</optional>
-		</dependency>
 	</dependencies>
 </project>

--- a/astrix-fault-tolerance/src/main/java/com/avanza/astrix/ft/hystrix/HystrixModule.java
+++ b/astrix-fault-tolerance/src/main/java/com/avanza/astrix/ft/hystrix/HystrixModule.java
@@ -15,7 +15,6 @@
  */
 package com.avanza.astrix.ft.hystrix;
 
-import org.kohsuke.MetaInfServices;
 import com.avanza.astrix.beans.config.AstrixConfig;
 import com.avanza.astrix.beans.ft.BeanFaultToleranceFactorySpi;
 import com.avanza.astrix.beans.ft.HystrixCommandNamingStrategy;
@@ -24,7 +23,6 @@ import com.avanza.astrix.context.AstrixContextPlugin;
 import com.avanza.astrix.context.AstrixStrategiesConfig;
 import com.avanza.astrix.modules.ModuleContext;
 
-@MetaInfServices(AstrixContextPlugin.class)
 public class HystrixModule implements AstrixContextPlugin {
 	
 	@Override

--- a/astrix-fault-tolerance/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
+++ b/astrix-fault-tolerance/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
@@ -1,0 +1,1 @@
+com.avanza.astrix.ft.hystrix.HystrixModule

--- a/astrix-gs-test-util/src/main/java/com/avanza/astrix/gs/test/util/PartitionedPu.java
+++ b/astrix-gs-test-util/src/main/java/com/avanza/astrix/gs/test/util/PartitionedPu.java
@@ -103,6 +103,7 @@ public final class PartitionedPu implements PuRunner {
 		return this.lookupGroupName;
 	}
 	
+	@Override
 	public boolean autostart() {
 		return this.autostart ;
 	}

--- a/astrix-gs/pom.xml
+++ b/astrix-gs/pom.xml
@@ -52,13 +52,6 @@
 			<artifactId>gs-openspaces</artifactId>
 		</dependency>
 		
-		<dependency>
-			<groupId>org.kohsuke.metainf-services</groupId>
-			<artifactId>metainf-services</artifactId>
-			<version>1.1</version>
-			<optional>true</optional>
-		</dependency>
-		
 		<!-- TEST -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/GsModule.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/GsModule.java
@@ -15,8 +15,6 @@
  */
 package com.avanza.astrix.gs;
 
-import org.kohsuke.MetaInfServices;
-
 import com.avanza.astrix.beans.core.ReactiveTypeHandlerPlugin;
 import com.avanza.astrix.beans.ft.BeanFaultToleranceFactory;
 import com.avanza.astrix.beans.service.ServiceComponent;
@@ -25,12 +23,12 @@ import com.avanza.astrix.context.AstrixContextPlugin;
 import com.avanza.astrix.context.AstrixStrategiesConfig;
 import com.avanza.astrix.modules.ModuleContext;
 import com.avanza.astrix.spring.AstrixSpringContext;
+
 /**
  * 
  * @author Elias Lindholm
  *
  */
-@MetaInfServices(AstrixContextPlugin.class)
 public class GsModule implements AstrixContextPlugin {
 
 	@Override

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/localview/GsLocalViewModule.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/localview/GsLocalViewModule.java
@@ -15,8 +15,6 @@
  */
 package com.avanza.astrix.gs.localview;
 
-import org.kohsuke.MetaInfServices;
-
 import com.avanza.astrix.beans.ft.BeanFaultToleranceFactory;
 import com.avanza.astrix.beans.service.ServiceComponent;
 import com.avanza.astrix.context.AstrixContextPlugin;
@@ -25,7 +23,6 @@ import com.avanza.astrix.gs.ClusteredProxyBinder;
 import com.avanza.astrix.modules.ModuleContext;
 import com.avanza.astrix.spring.AstrixSpringContext;
 
-@MetaInfServices(AstrixContextPlugin.class)
 public class GsLocalViewModule implements AstrixContextPlugin  {
 
 	@Override

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/remoting/GsRemotingModule.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/remoting/GsRemotingModule.java
@@ -15,8 +15,6 @@
  */
 package com.avanza.astrix.gs.remoting;
 
-import org.kohsuke.MetaInfServices;
-
 import com.avanza.astrix.beans.core.ReactiveTypeConverter;
 import com.avanza.astrix.beans.ft.BeanFaultToleranceFactory;
 import com.avanza.astrix.beans.service.ServiceComponent;
@@ -28,7 +26,7 @@ import com.avanza.astrix.modules.ModuleContext;
 import com.avanza.astrix.remoting.server.AstrixServiceActivator;
 import com.avanza.astrix.spring.AstrixSpringContext;
 import com.avanza.astrix.versioning.core.ObjectSerializerFactory;
-@MetaInfServices(AstrixContextPlugin.class)
+
 public class GsRemotingModule implements AstrixContextPlugin {
 
 	@Override
@@ -37,6 +35,7 @@ public class GsRemotingModule implements AstrixContextPlugin {
 
 	@Override
 	public void prepare(ModuleContext moduleContext) {
+		ensureGigaSpaceJavaCompatibility();
 		moduleContext.bind(ServiceComponent.class, GsRemotingComponent.class);
 		
 		moduleContext.importType(ObjectSerializerFactory.class);
@@ -50,4 +49,17 @@ public class GsRemotingModule implements AstrixContextPlugin {
 		moduleContext.export(ServiceComponent.class);
 	}
 
+	private void ensureGigaSpaceJavaCompatibility() {
+		final String jreVersion = System.getProperty("java.specification.version");
+		if (jreVersion.matches("\\d+")) {
+			int jreVersionInt = Integer.parseInt(jreVersion);
+			if (jreVersionInt >= 11) {
+				throw new IllegalArgumentException(
+						"This JRE seems to be Java 11 or later."
+								+ " GigaSpaces v10.x is unable to run on this JRE."
+								+ " Please upgrade GigaSpaces or use a Java 8 JRE."
+				);
+			}
+		}
+	}
 }

--- a/astrix-gs/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
+++ b/astrix-gs/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
@@ -1,0 +1,3 @@
+com.avanza.astrix.gs.GsModule
+com.avanza.astrix.gs.localview.GsLocalViewModule
+com.avanza.astrix.gs.remoting.GsRemotingModule

--- a/astrix-metrics/pom.xml
+++ b/astrix-metrics/pom.xml
@@ -19,13 +19,6 @@
 			<groupId>io.dropwizard.metrics</groupId>
 			<artifactId>metrics-core</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.kohsuke.metainf-services</groupId>
-			<artifactId>metainf-services</artifactId>
-			<version>1.1</version>
-			<optional>true</optional>
-		</dependency>
-		
 		
 		<dependency>
 			<groupId>junit</groupId>

--- a/astrix-metrics/src/main/java/com/avanza/astrix/metrics/DropwizardPlugin.java
+++ b/astrix-metrics/src/main/java/com/avanza/astrix/metrics/DropwizardPlugin.java
@@ -15,14 +15,11 @@
  */
 package com.avanza.astrix.metrics;
 
-import org.kohsuke.MetaInfServices;
-
 import com.avanza.astrix.context.AstrixContextPlugin;
 import com.avanza.astrix.context.AstrixStrategiesConfig;
 import com.avanza.astrix.context.metrics.MetricsSpi;
 import com.avanza.astrix.modules.ModuleContext;
 
-@MetaInfServices(AstrixContextPlugin.class)
 public class DropwizardPlugin implements AstrixContextPlugin {
 
 	@Override

--- a/astrix-metrics/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
+++ b/astrix-metrics/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
@@ -1,0 +1,1 @@
+com.avanza.astrix.metrics.DropwizardPlugin

--- a/astrix-modules/pom.xml
+++ b/astrix-modules/pom.xml
@@ -12,7 +12,10 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
-		
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/astrix-netty-remoting/pom.xml
+++ b/astrix-netty-remoting/pom.xml
@@ -18,13 +18,6 @@
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.kohsuke.metainf-services</groupId>
-			<artifactId>metainf-services</artifactId>
-			<version>1.1</version>
-			<optional>true</optional>
-		</dependency>
-		
 		
 		<dependency>
 			<groupId>junit</groupId>

--- a/astrix-netty-remoting/src/main/java/com/avanza/astrix/netty/NettyRemotingModule.java
+++ b/astrix-netty-remoting/src/main/java/com/avanza/astrix/netty/NettyRemotingModule.java
@@ -15,8 +15,6 @@
  */
 package com.avanza.astrix.netty;
 
-import org.kohsuke.MetaInfServices;
-
 import com.avanza.astrix.beans.config.AstrixConfig;
 import com.avanza.astrix.beans.service.ServiceComponent;
 import com.avanza.astrix.context.AstrixContextPlugin;
@@ -25,7 +23,6 @@ import com.avanza.astrix.remoting.client.RemotingProxyFactory;
 import com.avanza.astrix.remoting.server.AstrixServiceActivator;
 import com.avanza.astrix.versioning.core.ObjectSerializerFactory;
 
-@MetaInfServices(AstrixContextPlugin.class)
 public class NettyRemotingModule implements AstrixContextPlugin {
 
 	@Override

--- a/astrix-netty-remoting/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
+++ b/astrix-netty-remoting/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
@@ -1,0 +1,1 @@
+com.avanza.astrix.netty.NettyRemotingModule

--- a/astrix-remoting/pom.xml
+++ b/astrix-remoting/pom.xml
@@ -33,13 +33,6 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.kohsuke.metainf-services</groupId>
-			<artifactId>metainf-services</artifactId>
-			<version>1.1</version>
-			<optional>true</optional>
-		</dependency>
-
 		<!-- TEST -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/RemotingClientModule.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/RemotingClientModule.java
@@ -16,15 +16,12 @@
 package com.avanza.astrix.remoting.client;
 
 
-import org.kohsuke.MetaInfServices;
-
 import com.avanza.astrix.beans.core.ReactiveTypeConverter;
 import com.avanza.astrix.beans.tracing.AstrixTraceProvider;
 import com.avanza.astrix.context.AstrixContextPlugin;
 import com.avanza.astrix.modules.ModuleContext;
 import com.avanza.astrix.versioning.core.ObjectSerializerFactory;
 
-@MetaInfServices(AstrixContextPlugin.class)
 public class RemotingClientModule implements AstrixContextPlugin {
 
 	@Override

--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/server/RemotingServerModule.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/server/RemotingServerModule.java
@@ -15,8 +15,6 @@
  */
 package com.avanza.astrix.remoting.server;
 
-import org.kohsuke.MetaInfServices;
-
 import com.avanza.astrix.beans.config.AstrixConfig;
 import com.avanza.astrix.beans.tracing.AstrixTraceProvider;
 import com.avanza.astrix.context.AstrixContextPlugin;
@@ -24,7 +22,7 @@ import com.avanza.astrix.context.AstrixStrategiesConfig;
 import com.avanza.astrix.context.mbeans.MBeanExporter;
 import com.avanza.astrix.context.metrics.Metrics;
 import com.avanza.astrix.modules.ModuleContext;
-@MetaInfServices(AstrixContextPlugin.class)
+
 public class RemotingServerModule implements AstrixContextPlugin {
 
 	@Override

--- a/astrix-remoting/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
+++ b/astrix-remoting/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
@@ -1,0 +1,2 @@
+com.avanza.astrix.remoting.client.RemotingClientModule
+com.avanza.astrix.remoting.server.RemotingServerModule

--- a/astrix-service-registry-pu/src/main/java/com/avanza/astrix/service/registry/pu/SpaceServiceRegistryEntry.java
+++ b/astrix-service-registry-pu/src/main/java/com/avanza/astrix/service/registry/pu/SpaceServiceRegistryEntry.java
@@ -21,10 +21,7 @@ import java.util.Map;
 import com.avanza.astrix.beans.registry.ServiceKey;
 import com.avanza.astrix.beans.registry.ServiceProviderKey;
 import com.gigaspaces.annotation.pojo.SpaceId;
-import com.gigaspaces.annotation.pojo.SpaceIndex;
-import com.gigaspaces.annotation.pojo.SpaceProperty;
 import com.gigaspaces.annotation.pojo.SpaceRouting;
-import com.gigaspaces.metadata.index.SpaceIndexType;
 
 public class SpaceServiceRegistryEntry implements Serializable {
 

--- a/astrix-service-registry/pom.xml
+++ b/astrix-service-registry/pom.xml
@@ -23,20 +23,7 @@
 		<artifactId>astrix-versioning</artifactId>
 		<version>${project.version}</version>
 	</dependency>
-	<dependency>
-		<groupId>com.gigaspaces</groupId>
-		<artifactId>gs-openspaces</artifactId>
-	</dependency>
-	
-	
-	
-	<dependency>
-		<groupId>org.kohsuke.metainf-services</groupId>
-		<artifactId>metainf-services</artifactId>
-		<version>1.1</version>
-		<optional>true</optional>
-	</dependency>
-	
+
 	<!-- TEST -->
 	<dependency>
 		<groupId>${project.groupId}</groupId>

--- a/astrix-spring/pom.xml
+++ b/astrix-spring/pom.xml
@@ -30,12 +30,6 @@
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.kohsuke.metainf-services</groupId>
-			<artifactId>metainf-services</artifactId>
-			<version>1.1</version>
-			<optional>true</optional>
-		</dependency>
 		
 		<!-- TEST -->
 		<dependency>

--- a/astrix-spring/src/main/java/com/avanza/astrix/spring/SpringModule.java
+++ b/astrix-spring/src/main/java/com/avanza/astrix/spring/SpringModule.java
@@ -15,12 +15,10 @@
  */
 package com.avanza.astrix.spring;
 
-import org.kohsuke.MetaInfServices;
-
 import com.avanza.astrix.context.AstrixContextPlugin;
 import com.avanza.astrix.context.AstrixStrategiesConfig;
 import com.avanza.astrix.modules.ModuleContext;
-@MetaInfServices(AstrixContextPlugin.class)
+
 public class SpringModule implements AstrixContextPlugin {
 
 	@Override

--- a/astrix-spring/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
+++ b/astrix-spring/src/main/resources/META-INF/services/com.avanza.astrix.context.AstrixContextPlugin
@@ -1,0 +1,1 @@
+com.avanza.astrix.spring.SpringModule

--- a/astrix-versioning/pom.xml
+++ b/astrix-versioning/pom.xml
@@ -18,13 +18,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 		
-		<dependency>
-			<groupId>org.kohsuke.metainf-services</groupId>
-			<artifactId>metainf-services</artifactId>
-			<version>1.1</version>
-			<optional>true</optional>
-		</dependency>
-		
 		<!-- Test -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
 		<module>astrix-service-registry-pu</module>
 		<module>astrix-test-util</module>
 		<module>astrix-gs-test-util</module>
-<!-- 		<module>astrix-dashboard</module> -->
 		<module>astrix-spring</module>
 		<module>astrix-http</module>
 		<module>astrix-remoting</module>
@@ -139,6 +138,8 @@
 		<additionalparam>-Xdoclint:none</additionalparam>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<log4j.version>1.2.16</log4j.version>
 		<spring.version>4.1.9.RELEASE</spring.version>
 		<spring.groupId>org.springframework</spring.groupId>
@@ -246,7 +247,14 @@
 				<artifactId>guava</artifactId>
 				<version>${guava.version}</version>
 			</dependency>
-			
+
+			<!-- Java 11 back-comp -->
+			<dependency>
+				<groupId>javax.annotation</groupId>
+				<artifactId>javax.annotation-api</artifactId>
+				<version>1.3.2</version>
+			</dependency>
+
 			<!-- Reflections for annotation scanning-->
 			<dependency>
 				<groupId>org.reflections</groupId>
@@ -442,7 +450,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.1</version>
+					<version>3.8.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -517,7 +525,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>2.12</version>
+					<version>3.0.0-M4</version>
+					<configuration>
+						<argLine>
+							--illegal-access=permit
+						</argLine>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -527,7 +540,10 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>versions-maven-plugin</artifactId>
-					<version>1.2</version>
+					<version>2.5</version>
+					<configuration>
+						<generateBackupPoms>false</generateBackupPoms>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -537,7 +553,14 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>1.4.1</version>
+					<version>3.0.0-M2</version>
+					<configuration>
+						<rules>
+							<requireMavenVersion>
+								<version>[3.0.4,)</version>
+							</requireMavenVersion>
+						</rules>
+					</configuration>
 				</plugin>
 				<plugin>
 				    <groupId>com.mycila</groupId>
@@ -571,6 +594,13 @@
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.ow2.asm</groupId>
+						<artifactId>asm</artifactId>
+						<version>6.2</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 
 			<!-- Configures jar creation and manifest contents -->
@@ -608,11 +638,24 @@
 			</plugin>
 
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-					<rules />
-				</configuration>
+				<executions>
+					<execution>
+						<id>enforce</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>[3.0.4,)</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<!-- TODO: Configuration of the versions plugin, so that only astrix 


### PR DESCRIPTION
* Backports changes from the `gs14` branch, in order to support compilation using a java11 jdk.
* Adds explicit exception during startup if the current jre will not support this version of GigaSpaces.
* Reason for backporting changes from the `gs14` branch is to make the diff on that branch smaller, and to make it possible to compile using java11, but still target java8 compatibility.