### PR TITLE
TP-325: Allow Astrix plugins for server- & client authentication (GS14)

### DIFF
--- a/astrix-gs-test-util/src/main/java/com/avanza/astrix/gs/test/util/PartitionedPuConfigurer.java
+++ b/astrix-gs-test-util/src/main/java/com/avanza/astrix/gs/test/util/PartitionedPuConfigurer.java
@@ -30,6 +30,7 @@ public final class PartitionedPuConfigurer {
 	String lookupGroupName = JVMGlobalLus.getLookupGroupName();
 	String spaceName = "test-space";
 	public boolean autostart = true;
+	boolean useAuthentication;
 
 	public PartitionedPuConfigurer(String puXmlPath) {
 		this.puXmlPath = puXmlPath;
@@ -87,4 +88,8 @@ public final class PartitionedPuConfigurer {
 		return this;
 	}
 
+	public PartitionedPuConfigurer withAuthentication() {
+		this.useAuthentication = true;
+		return this;
+	}
 }

--- a/astrix-gs-test-util/src/main/java/com/avanza/astrix/gs/test/util/SecurityManagerForTests.java
+++ b/astrix-gs-test-util/src/main/java/com/avanza/astrix/gs/test/util/SecurityManagerForTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.gs.test.util;
+
+import java.io.Serializable;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import com.gigaspaces.security.AccessDeniedException;
+import com.gigaspaces.security.Authentication;
+import com.gigaspaces.security.AuthenticationException;
+import com.gigaspaces.security.Authority;
+import com.gigaspaces.security.SecurityException;
+import com.gigaspaces.security.SecurityManager;
+import com.gigaspaces.security.authorities.SpaceAuthority;
+import com.gigaspaces.security.directory.DirectoryManager;
+import com.gigaspaces.security.directory.User;
+import com.gigaspaces.security.directory.UserDetails;
+
+public class SecurityManagerForTests implements SecurityManager, Serializable {
+
+	public static final String TEST_USER = "testuser";
+	public static final String TEST_PASS = "testpass";
+	private static final Authority[] TEST_AUTHORITIES = Stream.of(SpaceAuthority.SpacePrivilege.values())
+			.map(SpaceAuthority::new)
+			.toArray(Authority[]::new);
+
+	@Override
+	public void init(Properties properties) throws SecurityException { }
+
+	@Override
+	public void close() { }
+
+	@Override
+	public DirectoryManager createDirectoryManager(UserDetails userDetails) throws AuthenticationException, AccessDeniedException {
+		throw new UnsupportedOperationException("DirectoryManager is not supported by SecurityManagerForTests");
+	}
+
+	@Override
+	public Authentication authenticate(UserDetails u) throws AuthenticationException {
+		if (!TEST_USER.equals(u.getUsername())) {
+			throw new AuthenticationException(
+					"Incorrect auth username for test login. "
+							+ "Expected [" + TEST_USER + "] but received [" + u.getUsername() + "]"
+			);
+		}
+		if (!TEST_PASS.equals(u.getPassword())) {
+			throw new AuthenticationException(
+					"Incorrect auth password for test login. "
+							+ "Expected [" + TEST_PASS + "] but received [" + u.getPassword() + "]"
+			);
+		}
+		return new Authentication(new User(TEST_USER, TEST_PASS, TEST_AUTHORITIES));
+	}
+}

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/GsBinder.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/GsBinder.java
@@ -19,10 +19,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.openspaces.core.GigaSpace;
-import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.context.ApplicationContext;
-
 import com.avanza.astrix.beans.core.AstrixConfigAware;
 import com.avanza.astrix.beans.core.AstrixSettings;
 import com.avanza.astrix.beans.service.ServiceProperties;
@@ -38,7 +36,8 @@ public class GsBinder implements AstrixConfigAware {
 	
 	public static final String SPACE_NAME_PROPERTY = "spaceName";
 	public static final String SPACE_URL_PROPERTY = "spaceUrl";
-	
+	private static final String SPACE_REQUIRES_AUTHENTICATION = "isSecured";
+
 	private static final Pattern SPACE_URL_PATTERN = Pattern.compile("jini://.*?/.*?/(.*)?[?](.*)");
 	private DynamicConfig config;
 	
@@ -75,12 +74,25 @@ public class GsBinder implements AstrixConfigAware {
 			return false;
 		}
 	}
-	
+
+	static String getSpaceName(ServiceProperties serviceProperties) {
+		return serviceProperties.getProperty(SPACE_NAME_PROPERTY);
+	}
+
+	static String getSpaceUrl(ServiceProperties serviceProperties) {
+		return serviceProperties.getProperty(SPACE_URL_PROPERTY);
+	}
+
+	static boolean isAuthenticationRequired(ServiceProperties serviceProperties) {
+		return Boolean.parseBoolean(serviceProperties.getProperty(SPACE_REQUIRES_AUTHENTICATION));
+	}
+
 	public ServiceProperties createProperties(GigaSpace space) {
 		ServiceProperties result = new ServiceProperties();
 //		result.setApi(GigaSpace.class);
 		result.setProperty(SPACE_NAME_PROPERTY, space.getSpace().getName());
 		result.setProperty(SPACE_URL_PROPERTY, new SpaceUrlBuilder(space).buildSpaceUrl());
+		result.setProperty(SPACE_REQUIRES_AUTHENTICATION, Boolean.toString(space.getSpace().isSecured()));
 		return result;
 	}
 

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/GsComponent.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/GsComponent.java
@@ -23,6 +23,8 @@ import com.avanza.astrix.beans.service.ServiceDefinition;
 import com.avanza.astrix.beans.service.ServiceProperties;
 import com.avanza.astrix.beans.service.UnsupportedTargetTypeException;
 import com.avanza.astrix.gs.ClusteredProxyCacheImpl.GigaSpaceInstance;
+import com.avanza.astrix.gs.security.GsSecurityManager;
+import com.avanza.astrix.gs.security.GsSecurityProvider;
 import com.avanza.astrix.provider.component.AstrixServiceComponentNames;
 import com.avanza.astrix.spring.AstrixSpringContext;
 /**
@@ -37,10 +39,16 @@ public class GsComponent implements ServiceComponent, ClusteredProxyBinder {
 	private AstrixSpringContext astrixSpringContext;
 	private ClusteredProxyCache proxyCache;
 	
-	public GsComponent(GsBinder gsBinder, AstrixSpringContext astrixSpringContext, ClusteredProxyCache proxyCache) {
+	public GsComponent(
+			GsBinder gsBinder,
+			AstrixSpringContext astrixSpringContext,
+			ClusteredProxyCache proxyCache,
+			GsSecurityProvider gsSecurityProvider
+	) {
 		this.gsBinder = gsBinder;
 		this.astrixSpringContext = astrixSpringContext;
 		this.proxyCache = proxyCache;
+		GsSecurityManager.setGsServerAuthenticator(gsSecurityProvider.getGsServerAuthenticator());
 	}
 
 	@Override

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/GsModule.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/GsModule.java
@@ -21,6 +21,8 @@ import com.avanza.astrix.beans.service.ServiceComponent;
 import com.avanza.astrix.beans.tracing.AstrixTraceProvider;
 import com.avanza.astrix.context.AstrixContextPlugin;
 import com.avanza.astrix.context.AstrixStrategiesConfig;
+import com.avanza.astrix.gs.security.DefaultGsSecurityProvider;
+import com.avanza.astrix.gs.security.GsSecurityProvider;
 import com.avanza.astrix.modules.ModuleContext;
 import com.avanza.astrix.spring.AstrixSpringContext;
 /**
@@ -41,7 +43,8 @@ public class GsModule implements AstrixContextPlugin {
 		moduleContext.importType(AstrixSpringContext.class);
 		moduleContext.importType(BeanFaultToleranceFactory.class);
 		moduleContext.importType(AstrixTraceProvider.class);
-		
+		moduleContext.importType(GsSecurityProvider.class);
+
 		moduleContext.export(ServiceComponent.class);
 		moduleContext.export(ClusteredProxyBinder.class);
 		moduleContext.export(ClusteredProxyCache.class);
@@ -50,6 +53,7 @@ public class GsModule implements AstrixContextPlugin {
 
 	@Override
 	public void registerStrategies(AstrixStrategiesConfig astrixContextConfig) {
+		astrixContextConfig.registerDefaultStrategy(GsSecurityProvider.class, DefaultGsSecurityProvider.class);
 	}
 
 }

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/security/DefaultGsSecurityProvider.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/security/DefaultGsSecurityProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.gs.security;
+
+import com.gigaspaces.security.AuthenticationException;
+import com.gigaspaces.security.directory.CredentialsProvider;
+
+public class DefaultGsSecurityProvider implements GsSecurityProvider {
+	@Override
+	public CredentialsProvider getGsClientCredentialsProvider(String spaceName) {
+		throw new UnsupportedOperationException("Client credentials are not supported by default in Astrix.");
+	}
+
+	@Override
+	public GsServerAuthenticator getGsServerAuthenticator() {
+		return u -> {
+			throw new AuthenticationException("Server authentication is not supported by default in Astrix.");
+		};
+	}
+}

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/security/GsSecurityManager.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/security/GsSecurityManager.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.gs.security;
+
+import java.util.Objects;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.avanza.astrix.gs.security.GsSecurityProvider.GsServerAuthenticator;
+import com.gigaspaces.security.AccessDeniedException;
+import com.gigaspaces.security.Authentication;
+import com.gigaspaces.security.AuthenticationException;
+import com.gigaspaces.security.SecurityException;
+import com.gigaspaces.security.SecurityManager;
+import com.gigaspaces.security.directory.DirectoryManager;
+import com.gigaspaces.security.directory.UserDetails;
+
+public class GsSecurityManager implements SecurityManager {
+	private static final Logger LOG = LoggerFactory.getLogger(GsSecurityManager.class);
+	private static GsServerAuthenticator authenticator;
+
+	/**
+	 * Default constructor without arguments is REQUIRED by GigaSpaces, since
+	 * it is created using reflection from
+	 * {@link com.gigaspaces.security.SecurityFactory#createSecurityManager}
+	 */
+	public GsSecurityManager() {
+		LOG.info("Created security manager");
+	}
+
+	public static void setGsServerAuthenticator(GsServerAuthenticator authenticator) {
+		GsSecurityManager.authenticator = Objects.requireNonNull(authenticator);
+		LOG.info("GsSecurityManager has been initialized with " + authenticator.getClass().getName());
+	}
+
+	@Override
+	public void init(Properties properties) throws SecurityException {
+	}
+
+	@Override
+	public Authentication authenticate(UserDetails userDetails) throws AuthenticationException {
+		if (authenticator == null) {
+			throw new AuthenticationException("GsSecurityManager is not initialized");
+		}
+		LOG.info("Authenticating user={}", userDetails.getUsername());
+		return authenticator.authenticate(userDetails);
+	}
+
+	@Override
+	public DirectoryManager createDirectoryManager(UserDetails userDetails) throws AuthenticationException, AccessDeniedException {
+		throw new UnsupportedOperationException("DirectoryManager not supported by GsSecurityManager");
+	}
+
+	@Override
+	public void close() {
+	}
+}
+

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/security/GsSecurityProvider.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/security/GsSecurityProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.gs.security;
+
+import com.gigaspaces.security.Authentication;
+import com.gigaspaces.security.directory.CredentialsProvider;
+import com.gigaspaces.security.directory.UserDetails;
+
+public interface GsSecurityProvider {
+	/**
+	 * Provides client credentials when making connections to a secured
+	 * GigaSpaces space. This method will be invoked when a new connection
+	 * is being established to a remote space. If the space does not require
+	 * authentication, this method will not be called.
+	 *
+	 * @param spaceName the name of the space that a client intends to
+	 *                  connect to
+	 * @return {@link CredentialsProvider}
+	 */
+	CredentialsProvider getGsClientCredentialsProvider(String spaceName);
+
+	/**
+	 * Provides a server-side authentication validator for credentials that the
+	 * server has received. This method will be invoked when the GigaSpaces
+	 * component is starting up (when the service is starting), regardless of
+	 * whether security is enabled or not. However, the methods on
+	 * {@link GsServerAuthenticator} will only be invoked for secured spaces
+	 * when the server has received client credentials.
+	 *
+	 * @return {@link GsServerAuthenticator}
+	 */
+	GsServerAuthenticator getGsServerAuthenticator();
+
+	interface GsServerAuthenticator {
+		Authentication authenticate(UserDetails userDetails);
+	}
+}

--- a/astrix-gs/src/main/resources/config/security/security.properties
+++ b/astrix-gs/src/main/resources/config/security/security.properties
@@ -1,0 +1,1 @@
+com.gs.security.security-manager.class=com.avanza.astrix.gs.security.GsSecurityManager

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/GigaSpacesAuthenticationTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/GigaSpacesAuthenticationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.integration.tests;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Properties;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.openspaces.core.space.CannotFindSpaceException;
+import com.avanza.astrix.beans.core.AstrixSettings;
+import com.avanza.astrix.beans.registry.InMemoryServiceRegistry;
+import com.avanza.astrix.beans.service.ServiceProperties;
+import com.avanza.astrix.beans.tracing.AstrixTraceProvider;
+import com.avanza.astrix.beans.tracing.DefaultTraceProvider;
+import com.avanza.astrix.config.GlobalConfigSourceRegistry;
+import com.avanza.astrix.config.MapConfigSource;
+import com.avanza.astrix.gs.ClusteredProxyCacheImpl;
+import com.avanza.astrix.gs.GsBinder;
+import com.avanza.astrix.gs.security.DefaultGsSecurityProvider;
+import com.avanza.astrix.gs.security.GsSecurityProvider;
+import com.avanza.astrix.gs.test.util.PuConfigurers;
+import com.avanza.astrix.gs.test.util.RunningPu;
+import com.avanza.astrix.gs.test.util.SecurityManagerForTests;
+import com.gigaspaces.security.directory.CredentialsProvider;
+import com.gigaspaces.security.directory.DefaultCredentialsProvider;
+import com.gigaspaces.security.directory.User;
+
+public class GigaSpacesAuthenticationTest {
+
+	private static final InMemoryServiceRegistry serviceRegistry = new InMemoryServiceRegistry();
+	private static final MapConfigSource settings = new MapConfigSource() {{
+		set(AstrixSettings.SERVICE_REGISTRY_URI, serviceRegistry.getServiceUri());
+	}};
+
+	// PU with authentication
+	@ClassRule
+	public static final RunningPu LUNCH_PU = PuConfigurers.partitionedPu("classpath:/META-INF/spring/lunch-pu.xml")
+			.contextProperty("configSourceId", GlobalConfigSourceRegistry.register(settings))
+			.beanProperties("space", new Properties() {{
+				// This is equivalent to configuring the pu in pu.xml like so:
+				// <os-core:space id="space" url="/./${spaceName}" mirror="false" versioned="true">
+				//   <os-core:security secured="true" />
+				// </os-core:space>
+				setProperty("secured", "true");
+			}})
+			.withAuthentication()
+			.configure();
+
+	// PU without authentication
+	@ClassRule
+	public static final RunningPu LUNCH_GRADER_PU = PuConfigurers.partitionedPu("classpath:/META-INF/spring/lunch-grader-pu.xml")
+			.contextProperty("configSourceId", GlobalConfigSourceRegistry.register(settings))
+			.configure();
+
+	private final AstrixTraceProvider traceProvider = new DefaultTraceProvider();
+	private final GsSecurityProvider mockGsSecurityProvider = new DefaultGsSecurityProvider() {
+		@Override
+		public CredentialsProvider getGsClientCredentialsProvider(String spaceName) {
+			return new DefaultCredentialsProvider(clientCredentials);
+		}
+	};
+	private final ServiceProperties lunchPuServiceProperties = new GsBinder().createProperties(LUNCH_PU.getClusteredGigaSpace());
+	private final ServiceProperties lunchGraderPuServiceProperties = new GsBinder().createProperties(LUNCH_GRADER_PU.getClusteredGigaSpace());
+	private final ClusteredProxyCacheImpl proxyCache = new ClusteredProxyCacheImpl(traceProvider, mockGsSecurityProvider);
+
+	/**
+	 * This are the client-side credentials that will be used when connecting to
+	 * {@link #LUNCH_PU}. The server-side will validate the credentials using
+	 * {@link SecurityManagerForTests}, and we have no good way of affecting the
+	 * server-side validator from these tests.
+	 */
+	private final User clientCredentials = new User(SecurityManagerForTests.TEST_USER, SecurityManagerForTests.TEST_PASS);
+
+	@Test
+	public void shouldAllowConnectingToGigaSpacesUsingClientCredentials() {
+		// Act
+		proxyCache.getProxy(lunchPuServiceProperties);
+
+		// Assert that no exceptions were thrown
+	}
+
+	@Test
+	public void shouldDisallowConnectingToGigaSpacesUsingClientCredentialsWithWrongPassword() {
+		// Arrange
+		clientCredentials.setPassword("incorrect");
+
+		// Act
+		try {
+			proxyCache.getProxy(lunchPuServiceProperties);
+
+			// Assert
+			fail("Expected an exception to be thrown here, but no exception was seen.");
+		} catch (CannotFindSpaceException e) {
+			assertThat(e.toString(), containsString("Failed to find space"));
+			assertThat(e.getRootCause().toString(), containsString("Incorrect auth password"));
+		}
+	}
+
+	@Test
+	public void shouldDisallowConnectingToSecuredGigaSpacesWithoutUsingClientCredentials() {
+		// Arrange
+		lunchPuServiceProperties.setProperty("isSecured", "false");
+
+		// Act
+		try {
+			proxyCache.getProxy(lunchPuServiceProperties).get().clear(null);
+
+			// Assert
+			fail("Expected an exception to be thrown here, but no exception was seen.");
+		} catch (Exception e) {
+			assertThat(e.toString(), containsString("No credentials were provided"));
+		}
+	}
+
+	@Test
+	public void shouldAllowConnectingToNonSecureGigaSpacesWithoutClientCredentials() {
+		// Act
+		proxyCache.getProxy(lunchGraderPuServiceProperties);
+
+		// Assert that no exceptions were thrown
+	}
+
+	@Test
+	public void shouldDisallowConnectingToNonSecureGigaSpacesUsingClientCredentials() {
+		// Arrange
+		lunchGraderPuServiceProperties.setProperty("isSecured", "true");
+
+		// Act
+		try {
+			proxyCache.getProxy(lunchGraderPuServiceProperties);
+
+			// Assert
+			fail("Expected an exception to be thrown here, but no exception was seen.");
+		} catch (CannotFindSpaceException e) {
+			assertThat(e.toString(), containsString("Failed to find space"));
+			assertThat(e.getRootCause().toString(), containsString("Can't provide security credentials to a non-secured space"));
+		}
+	}
+}

--- a/astrix-integration-tests/src/test/resources/log4j.properties
+++ b/astrix-integration-tests/src/test/resources/log4j.properties
@@ -1,6 +1,6 @@
 # Root logger option
-log4j.rootLogger=WARN, stdout
-log4j.category.com.avanza=WARN
+log4j.rootLogger=INFO, stdout
+log4j.category.com.avanza=INFO
 log4j.category.com.avanza.astrix.beans=WARN
  
 # Direct log messages to stdout


### PR DESCRIPTION
* Adds `GsSecurityProvider` interface that can be overridden in an Astrix plugin to supply a serverside authenticator and client-side credentials.
* Adds wiring in Astrix so that started PUs will use the security provider if the space has enabled `<os-core:security secured="true" />`.
* Adds class `GsSecurityManager` as an implementation of GigaSpaces server-side `SecurityManager`, which will delegate server-side authentication to the class provided by `GsSecurityProvider`.