### PR TITLE
TP-431: Use explicit groupname for gs-test

### DIFF
--- a/astrix-integration-tests/pom.xml
+++ b/astrix-integration-tests/pom.xml
@@ -44,7 +44,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>${gs-test.groupId}</groupId>
+			<groupId>com.avanza.gs</groupId>
 			<artifactId>gs-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/doc-snippets/pom.xml
+++ b/doc-snippets/pom.xml
@@ -25,7 +25,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>${gs-test.groupId}</groupId>
+			<groupId>com.avanza.gs</groupId>
 			<artifactId>gs-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/example-application-runners/pom.xml
+++ b/examples/example-application-runners/pom.xml
@@ -18,7 +18,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>${gs-test.groupId}</groupId>
+			<groupId>com.avanza.gs</groupId>
 			<artifactId>gs-test</artifactId>
 		</dependency>
 		<dependency>

--- a/examples/lunch-grader-parent/lunch-grader-pu/pom.xml
+++ b/examples/lunch-grader-parent/lunch-grader-pu/pom.xml
@@ -49,7 +49,7 @@
 			<artifactId>astrix-service-registry</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>${gs-test.groupId}</groupId>
+			<groupId>com.avanza.gs</groupId>
 			<artifactId>gs-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/lunch-parent/lunch-pu/pom.xml
+++ b/examples/lunch-parent/lunch-pu/pom.xml
@@ -44,7 +44,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>${gs-test.groupId}</groupId>
+			<groupId>com.avanza.gs</groupId>
 			<artifactId>gs-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/lunch-tests/pom.xml
+++ b/examples/lunch-tests/pom.xml
@@ -20,7 +20,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>${gs-test.groupId}</groupId>
+			<groupId>com.avanza.gs</groupId>
 			<artifactId>gs-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@
 		<lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
 		<dropwizard.version>3.1.2</dropwizard.version>
 		<netty.version>4.0.31.Final</netty.version>
-		<gs-test.groupId>com.avanza.gs</gs-test.groupId>
 	</properties>
 
 	<dependencyManagement>
@@ -405,9 +404,9 @@
 				<version>${archaius.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>${gs-test.groupId}</groupId>
+				<groupId>com.avanza.gs</groupId>
 				<artifactId>gs-test</artifactId>
-				<version>0.1.12</version>
+				<version>0.1.15</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/tutorial/trading-api-parent/trading-pu/pom.xml
+++ b/tutorial/trading-api-parent/trading-pu/pom.xml
@@ -44,7 +44,7 @@
   		<scope>test</scope>
   	</dependency>
   	<dependency>
-		<groupId>${gs-test.groupId}</groupId>
+		<groupId>com.avanza.gs</groupId>
 		<artifactId>gs-test</artifactId>
   		<scope>test</scope>
   	</dependency>


### PR DESCRIPTION
* Replaces the variable (from property) groupname of `gs-test` to an explicit value that is not read from a property.
* Reason for changing is that using a property value for groupname does not seem to work when updating this dependency with `mvn versions:use-latest-versions` (the dependency is not updated).