### PR TITLE
Bump `versions-maven-plugin` to `2.8.1`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -409,17 +409,17 @@
 			<dependency>
 				<groupId>com.avanza.gs</groupId>
 				<artifactId>gs-test</artifactId>
-				<version>0.1.15</version>
+				<version>${gs-test.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.avanza.mimer</groupId>
 				<artifactId>mimer-config</artifactId>
-				<version>0.0.4</version>
+				<version>${mimer-config.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.avanza.hystrix</groupId>
 				<artifactId>hystrix-multiconfig</artifactId>
-				<version>0.0.3</version>
+				<version>${hystrix-multiconfig.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -542,7 +542,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>versions-maven-plugin</artifactId>
-					<version>2.5</version>
+					<version>2.8.1</version>
 					<configuration>
 						<generateBackupPoms>false</generateBackupPoms>
 					</configuration>


### PR DESCRIPTION
* `versions-maven-plugin` seems to replace parameterized versions with the explicit version, instead of updating the parameter value.
* Updated versions of `versions-maven-plugin` seem to work correctly (the parameter value is instead updated)
* This reverts commit b457a81513f4e7cd8a8c7e3da77dec8312967cb2.