### PR TITLE
Bump `versions-maven-plugin` to `2.8.1` (gs14)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,17 +344,17 @@
 			<dependency>
 				<groupId>com.avanza.gs14</groupId>
 				<artifactId>gs-test</artifactId>
-				<version>14.0.8</version>
+				<version>${gs-test.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.avanza.mimer</groupId>
 				<artifactId>mimer-config</artifactId>
-				<version>0.0.4</version>
+				<version>${mimer-config.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.avanza.hystrix</groupId>
 				<artifactId>hystrix-multiconfig</artifactId>
-				<version>0.0.3</version>
+				<version>${hystrix-multiconfig.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -477,7 +477,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>versions-maven-plugin</artifactId>
-					<version>2.5</version>
+					<version>2.8.1</version>
 					<configuration>
 						<generateBackupPoms>false</generateBackupPoms>
 					</configuration>


### PR DESCRIPTION
* `versions-maven-plugin` seems to replace parameterized versions with the explicit version, instead of updating the parameter value.
* Updated versions of `versions-maven-plugin` seem to work correctly (the parameter value is instead updated)
* This reverts commit 2157d3c484fe5920f098624aebe3d33f85e25f80.