### PR TITLE
Log register and unregister MBean on info level

### DIFF
--- a/astrix-context/src/main/java/com/avanza/astrix/context/mbeans/PlatformMBeanServer.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/context/mbeans/PlatformMBeanServer.java
@@ -50,7 +50,7 @@ public class PlatformMBeanServer implements MBeanServerFacade {
 	public void registerMBean(Object mbean, String folder, String name) {
 		try {
 			ObjectName objectName = getObjectName(folder, name);
-			logger.debug("Register mbean: name={}", objectName);
+			logger.info("Register mbean: name={}", objectName);
 			ManagementFactory.getPlatformMBeanServer().registerMBean(mbean, objectName);
 			exportedMbeans.putIfAbsent(objectName, objectName);
 		} catch (Exception e) {
@@ -73,7 +73,7 @@ public class PlatformMBeanServer implements MBeanServerFacade {
 	
 	private void unregisterMBean(ObjectName objectName) {
 		try {
-			logger.debug("Unregister mbean: name={}", objectName);
+			logger.info("Unregister mbean: name={}", objectName);
 			ManagementFactory.getPlatformMBeanServer().unregisterMBean(objectName);
 		} catch (Exception e) {
 			logger.warn("Failed to unregister mbean: name={}", objectName);


### PR DESCRIPTION
The purpose of this PR is to be able to in the logs identify exported server side services on INFO level at startup. If there is a better place to achieve this than to use PlatformMBeanServer, please suggest that instead.