### PR TITLE
TP-559: Log server and client apis and impls (GS14)

### DIFF
--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/RemotingProxy.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/RemotingProxy.java
@@ -37,6 +37,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.avanza.astrix.beans.core.ReactiveTypeConverter;
 import com.avanza.astrix.core.AstrixCallStackTrace;
 import com.avanza.astrix.core.remoting.RoutingStrategy;
@@ -52,6 +55,8 @@ import rx.subjects.ReplaySubject;
  *
  */
 public class RemotingProxy implements InvocationHandler {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RemotingProxy.class);
 	
 	private final int apiVersion;
 	private final String serviceApi;
@@ -107,6 +112,7 @@ public class RemotingProxy implements InvocationHandler {
 			remoteServiceMethodByMethod.put(proxiedMethod, remoteServiceMethod);
 			invocationWatchersByMethod.put(proxiedMethod, astrixTraceProvider.getClientCallExecutionWatchers(serviceApi, proxiedMethod.getName()));
 		}
+		LOG.info("Initialized Astrix remoting client, consuming api=[{}] using proxiedApi=[{}]", targetServiceApi.getName(), proxiedServiceApi.getName());
 	}
 
 	@Override

--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/server/AstrixServiceActivatorImpl.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/server/AstrixServiceActivatorImpl.java
@@ -253,6 +253,7 @@ class AstrixServiceActivatorImpl implements AstrixServiceActivator {
 			throw new IllegalArgumentException("Provider: " + provider.getClass() + " does not implement: " + publishedApi);
 		}
 		PublishedService<?> publishedService = new PublishedService<>(provider, objectSerializer, publishedApi);
+		logger.info("Initialized Astrix remoting server, providing api=[{}] from provider=[{}]", publishedApi.getName(), provider.getClass().getName());
 		this.serviceByType.put(publishedApi.getName(), publishedService);
 	}
 	


### PR DESCRIPTION
* Same as #88 , but for gs14
* Logs all apis provided by Astrix remoting servers
* Logs all apis consumed as Astrix remoting clients

Example logging:
Client:
```
[2020-12-14 15:27:37.283] INFO  com.avanza.astrix.remoting.client.RemotingProxy - Initialized Astrix remoting client, consuming api=[com.avanza.astrix.beans.registry.AstrixServiceRegistry] using proxiedApi=[com.avanza.astrix.beans.registry.AstrixServiceRegistry]
[2020-12-14 15:27:37.694] INFO  com.avanza.astrix.remoting.client.RemotingProxy - Initialized Astrix remoting client, consuming api=[se.example.ExternalMessagingService] using proxiedApi=[se.example.ExternalMessagingServiceAsync]
```

Server:
```
[2020-12-14 15:27:15,094] INFO  com.avanza.astrix.remoting.server.AstrixServiceActivatorImpl - Initialized Astrix remoting server, providing api=[se.example.ExampleCallbackService] from provider=[se.example.ExampleCallbackServiceImpl]
[2020-12-14 15:27:15,094] INFO  com.avanza.astrix.remoting.server.AstrixServiceActivatorImpl - Initialized Astrix remoting server, providing api=[se.example.ExternalMessagingService] from provider=[se.example.ExternalMessagingServiceImpl]
[2020-12-14 15:27:15,186] INFO  com.avanza.astrix.remoting.server.AstrixServiceActivatorImpl - Initialized Astrix remoting server, providing api=[com.avanza.astrix.serviceunit.ServiceAdministrator] from provider=[com.avanza.astrix.serviceunit.ServiceAdministratorImpl]
[2020-12-14 15:27:15,226] INFO  com.avanza.astrix.remoting.client.RemotingProxy - Initialized Astrix remoting client, consuming api=[com.avanza.astrix.beans.registry.AstrixServiceRegistry] using proxiedApi=[com.avanza.astrix.beans.registry.AstrixServiceRegistry]
```