### PR TITLE
TP-322: Apply contextpropagators on async callbacks

### DIFF
--- a/astrix-context/src/main/java/com/avanza/astrix/beans/async/ContextPropagator.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/async/ContextPropagator.java
@@ -17,6 +17,15 @@ package com.avanza.astrix.beans.async;
 
 import com.avanza.astrix.core.function.CheckedCommand;
 
+/**
+ * Defines actions that may be applied to an operation before it is executed.
+ * For example, this might be a decoration of the call state for a particular
+ * function, or logging of a certain call.
+ * In Astrix, this is used to carry along thread state when switching execution
+ * to a different thread. The state of the calling thread can be retrieved when
+ * {@link #wrap} is called, and later restored on another thread by the
+ * operation returned by the wrapping operation.
+ */
 public interface ContextPropagator {
 
     <T> CheckedCommand<T> wrap(CheckedCommand<T> call);

--- a/astrix-context/src/test/java/com/avanza/astrix/beans/async/ContextPropagationTest.java
+++ b/astrix-context/src/test/java/com/avanza/astrix/beans/async/ContextPropagationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.beans.async;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.Test;
+import com.avanza.astrix.core.function.CheckedCommand;
+
+public class ContextPropagationTest {
+	private final List<String> operations = new ArrayList<>();
+	private final ContextPropagator propagator = new ContextPropagator() {
+		@Override
+		public <T> CheckedCommand<T> wrap(CheckedCommand<T> call) {
+			return call;
+		}
+
+		@Override
+		public Runnable wrap(Runnable runnable) {
+			operations.add("wrap");
+			return () -> {
+				operations.add("before runnable");
+				runnable.run();
+				operations.add("after runnable");
+			};
+		}
+	};
+	private final ContextPropagation propagation = new ContextPropagation(Collections.singletonList(propagator));
+
+	@Test
+	public void shouldWrapRunnable() {
+		// Arrange
+		operations.add("before");
+		final Runnable action = propagation.wrap(() -> {
+			operations.add("action");
+		});
+		operations.add("after");
+
+		// Act
+		action.run();
+
+		// Assert
+		final List<String> expected = Arrays.asList(
+				"before",
+				"wrap",
+				"after",
+				"before runnable",
+				"action",
+				"after runnable"
+		);
+		assertEquals(expected, operations);
+	}
+
+	@Test
+	public void shouldWrapConsumer() {
+		// Arrange
+		operations.add("before");
+		final Consumer<String> consumer = propagation.wrap(v -> {
+			operations.add("consumer: " + v);
+		});
+		operations.add("after");
+
+		// Act
+		consumer.accept("value");
+
+		// Assert
+		final List<String> expected = Arrays.asList(
+				"before",
+				"wrap",
+				"after",
+				"before runnable",
+				"consumer: value",
+				"after runnable"
+		);
+		assertEquals(expected, operations);
+	}
+}

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/SpaceTaskDispatcher.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/SpaceTaskDispatcher.java
@@ -127,7 +127,7 @@ public final class SpaceTaskDispatcher {
 		usingErrorReporter(subscriber, serviceUnavailable()).accept(() -> {
 			// Submit task on current thread in executorService
 			AsyncFuture<T> taskResult = gigaSpace.execute(task, routingKey);
-			GsUtil.subscribe(taskResult, subscriber);
+			GsUtil.subscribe(taskResult, subscriber, contextPropagation);
 		});
 	}
 	
@@ -152,7 +152,7 @@ public final class SpaceTaskDispatcher {
 		usingErrorReporter(t1, serviceUnavailable()).accept(() -> {
 			// Submit task on current thread in executorService
 			AsyncFuture<R> taskResult = gigaSpace.execute(distributedTask);
-			GsUtil.subscribe(taskResult, t1);
+			GsUtil.subscribe(taskResult, t1, contextPropagation);
 		});
 	}
 	

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/SpaceTaskDispatcher.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/SpaceTaskDispatcher.java
@@ -30,6 +30,7 @@ import org.openspaces.core.executor.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.avanza.astrix.beans.async.ContextPropagation;
+import com.avanza.astrix.config.DynamicBooleanProperty;
 import com.avanza.astrix.config.DynamicConfig;
 import com.avanza.astrix.config.DynamicIntProperty;
 import com.avanza.astrix.core.ServiceUnavailableException;
@@ -62,6 +63,7 @@ public final class SpaceTaskDispatcher {
 	private final GigaSpace gigaSpace;
 	private final ContextPropagation contextPropagation;
 	private final ThreadPoolExecutor executorService;
+	private final DynamicBooleanProperty propagateAsyncContexts;
 
 	/**
 	 * @deprecated please use {@link #SpaceTaskDispatcher(GigaSpace, DynamicConfig, ContextPropagation)}
@@ -93,6 +95,10 @@ public final class SpaceTaskDispatcher {
 			executorService.setCorePoolSize(newValue);
 			executorService.setMaximumPoolSize(newValue);
 		});
+		this.propagateAsyncContexts = config.getBooleanProperty(
+				"com.avanza.astrix.gs.SpaceTaskDispatcher.propagateAsyncContexts",
+				true
+		);
 	}
 
 
@@ -127,7 +133,11 @@ public final class SpaceTaskDispatcher {
 		usingErrorReporter(subscriber, serviceUnavailable()).accept(() -> {
 			// Submit task on current thread in executorService
 			AsyncFuture<T> taskResult = gigaSpace.execute(task, routingKey);
-			GsUtil.subscribe(taskResult, subscriber, contextPropagation);
+			if (propagateAsyncContexts.get()) {
+				GsUtil.subscribe(taskResult, subscriber, contextPropagation);
+			} else {
+				GsUtil.subscribe(taskResult, subscriber);
+			}
 		});
 	}
 	
@@ -152,7 +162,11 @@ public final class SpaceTaskDispatcher {
 		usingErrorReporter(t1, serviceUnavailable()).accept(() -> {
 			// Submit task on current thread in executorService
 			AsyncFuture<R> taskResult = gigaSpace.execute(distributedTask);
-			GsUtil.subscribe(taskResult, t1, contextPropagation);
+			if (propagateAsyncContexts.get()) {
+				GsUtil.subscribe(taskResult, t1, contextPropagation);
+			} else {
+				GsUtil.subscribe(taskResult, t1);
+			}
 		});
 	}
 	

--- a/astrix-gs/src/main/java/com/avanza/astrix/remoting/util/GsUtil.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/remoting/util/GsUtil.java
@@ -58,7 +58,15 @@ public class GsUtil {
 			return new RemoteServiceInvocationException("Remote service threw exception: " + exception.getMessage(), exception.getClass().getName());
 		}
 	}
-	
+
+	/**
+	 * @deprecated Please use {@link #subscribe(AsyncFuture, Subscriber, ContextPropagation)} instead.
+	 */
+	@Deprecated
+	public static <T> void subscribe(final AsyncFuture<T> asyncFuture, final Subscriber<? super T> t1) {
+		subscribe(asyncFuture, t1, ContextPropagation.NONE);
+	}
+
 	public static <T> void subscribe(
 			final AsyncFuture<T> asyncFuture,
 			final Subscriber<? super T> t1,

--- a/astrix-gs/src/test/java/com/avanza/astrix/remoting/util/GsUtilTest.java
+++ b/astrix-gs/src/test/java/com/avanza/astrix/remoting/util/GsUtilTest.java
@@ -15,20 +15,35 @@
  */
 package com.avanza.astrix.remoting.util;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.junit.Test;
-
+import com.avanza.astrix.beans.async.ContextPropagation;
 import com.gigaspaces.async.AsyncResult;
+import com.gigaspaces.async.SettableFuture;
 import com.gigaspaces.async.internal.DefaultAsyncResult;
 
 import rx.Observable;
+import rx.Subscriber;
 import rx.functions.Func1;
+import rx.observers.Subscribers;
 
 public class GsUtilTest {
 
@@ -63,4 +78,82 @@ public class GsUtilTest {
 		private static final long serialVersionUID = 1L;
 	}
 
+
+	private final AtomicReference<String> onNext = new AtomicReference<>();
+	private final AtomicReference<Throwable> onError = new AtomicReference<>();
+	private final AtomicBoolean isCompleted = new AtomicBoolean();
+	private final SettableFuture<String> asyncFuture = new SettableFuture<>();
+	private final Subscriber<String> subscriber = Subscribers.create(
+			onNext::set,
+			onError::set,
+			() -> isCompleted.set(true)
+	);
+	private final ContextPropagation propagation = ContextPropagation.NONE;
+
+	@Test
+	public void shouldSetSubscriberOnNextUsingAsyncFutureValue() {
+		// Arrange
+		GsUtil.subscribe(asyncFuture, subscriber, propagation);
+
+		// Act
+		asyncFuture.setResult("result");
+
+		// Assert
+		assertEquals("result", onNext.get());
+		assertNull(onError.get());
+		assertTrue(isCompleted.get());
+	}
+
+	@Test
+	public void shouldSetSubscriberOnErrorUsingAsyncFutureException() {
+		// Arrange
+		GsUtil.subscribe(asyncFuture, subscriber, propagation);
+
+		// Act
+		asyncFuture.setResult(new RuntimeException("should set onError"));
+
+		// Assert
+		assertNull(onNext.get());
+		assertThat(onError.get(), instanceOf(RuntimeException.class));
+		assertEquals("should set onError", onError.get().getMessage());
+		assertFalse(isCompleted.get());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void shouldSetSubscriberOnNextUsingAsyncFutureValueWithContextPropagators() {
+		// Arrange
+		final List<String> operations = new ArrayList<>();
+		final ContextPropagation propagation = mock(ContextPropagation.class);
+		doAnswer(i -> {
+			operations.add("wrap");
+			final Consumer<AsyncResult<String>> consumer = (Consumer<AsyncResult<String>>) i.getArguments()[0];
+			return (Consumer<AsyncResult<String>>) c -> {
+				operations.add("before consumer");
+				consumer.accept(c);
+				operations.add("after consumer");
+			};
+		}).when(propagation).wrap(any(Consumer.class));
+
+		operations.add("first");
+		GsUtil.subscribe(asyncFuture, subscriber, propagation);
+
+		// Act
+		operations.add("before");
+		asyncFuture.setResult("result");
+		operations.add("after");
+
+		// Assert
+		assertEquals("result", onNext.get());
+		assertTrue(isCompleted.get());
+		final List<String> expected = Arrays.asList(
+				"first",
+				"wrap",
+				"before",
+				"before consumer",
+				"after consumer",
+				"after"
+		);
+		assertEquals(expected, operations);
+	}
 }


### PR DESCRIPTION
* Applies all `ContextPropagator`s on async callbacks.
* Reason for applying them is so that if the calling application has defined operations that carry thread state to other threads, we also want to carry along that state to the threads that execute async callbacks.
* In effect, this will make contextpropagation also work on Astrix clients after an async call has completed, when the callback is executed - the context will be propagated also to these callbacks.