### PR TITLE
TP-636 - Remove all compilation warnings

### DIFF
--- a/astrix-context/src/main/java/com/avanza/astrix/beans/core/CompletableFutureTypeHandlerPlugin.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/core/CompletableFutureTypeHandlerPlugin.java
@@ -46,6 +46,7 @@ public class CompletableFutureTypeHandlerPlugin implements ReactiveTypeHandlerPl
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public Class<CompletableFuture<Object>> reactiveTypeHandled() {
 		Class<?> result = CompletableFuture.class;
 		return (Class<CompletableFuture<Object>>) result;

--- a/astrix-context/src/main/java/com/avanza/astrix/beans/core/ReactiveTypeConverterImpl.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/core/ReactiveTypeConverterImpl.java
@@ -36,7 +36,7 @@ public final class ReactiveTypeConverterImpl implements ReactiveTypeConverter {
 	@Override
 	public <T> Observable<Object> toObservable(Class<T> fromType, T reactiveType) {
 		ReactiveTypeHandlerPlugin<T> plugin = getPlugin(fromType);
-		return Observable.create((s) -> {
+		return Observable.unsafeCreate((s) -> {
 			plugin.subscribe(new ReactiveExecutionListener() {
 				@Override
 				public void onResult(Object result) {
@@ -61,6 +61,7 @@ public final class ReactiveTypeConverterImpl implements ReactiveTypeConverter {
 	}
 	
 	private <T> ReactiveTypeHandlerPlugin<T> getPlugin(Class<T> type) {
+		@SuppressWarnings("unchecked")
 		ReactiveTypeHandlerPlugin<T> plugin = (ReactiveTypeHandlerPlugin<T>) this.pluginByReactiveType.get(type);
 		if (plugin == null) {
 			throw new IllegalArgumentException("Cant convert reactive type to rx.Observable. No ReactiveTypeHandlerPlugin registered for type: " + type);

--- a/astrix-context/src/main/java/com/avanza/astrix/beans/service/DirectComponent.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/service/DirectComponent.java
@@ -85,7 +85,7 @@ public class DirectComponent implements ServiceComponent {
 			public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
 				try {
 					Method targetMethod = targetProvider.getClass().getMethod(method.getName(), method.getParameterTypes());
-					Observable<Object> observableResult = Observable.create((s) -> {
+					Observable<Object> observableResult = Observable.unsafeCreate((s) -> {
 						try {
 							Object result = ReflectionUtil.invokeMethod(targetMethod, targetProvider, args);
 							s.onNext(result);

--- a/astrix-context/src/main/java/com/avanza/astrix/context/AstrixConfigurer.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/context/AstrixConfigurer.java
@@ -77,6 +77,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -237,8 +238,8 @@ public class AstrixConfigurer {
 
 	private AstrixDynamicConfigFactory initFactory(String dynamicConfigFactoryClass) {
 		try {
-			return (AstrixDynamicConfigFactory) Class.forName(dynamicConfigFactoryClass).newInstance();
-		} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+			return (AstrixDynamicConfigFactory) Class.forName(dynamicConfigFactoryClass).getDeclaredConstructor().newInstance();
+		} catch (InstantiationException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
 			throw new RuntimeException("Failed to init AstrixDynamicConfigFactoryClass: " + dynamicConfigFactoryClass, e);
 		}
 	}

--- a/astrix-context/src/main/java/com/avanza/astrix/context/AstrixSettings.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/context/AstrixSettings.java
@@ -24,6 +24,7 @@ import com.avanza.astrix.config.StringSetting;
  * @deprecated - Moved to {@link com.avanza.astrix.beans.core.AstrixSettings}
  *
  */
+@Deprecated
 public class AstrixSettings {
 	
 	

--- a/astrix-context/src/test/java/com/avanza/astrix/beans/service/ServiceBeanInstanceTest.java
+++ b/astrix-context/src/test/java/com/avanza/astrix/beans/service/ServiceBeanInstanceTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/astrix-context/src/test/java/com/avanza/astrix/context/AstrixApiProviderClassScannerTest.java
+++ b/astrix-context/src/test/java/com/avanza/astrix/context/AstrixApiProviderClassScannerTest.java
@@ -16,6 +16,7 @@
 package com.avanza.astrix.context;
 
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
@@ -23,9 +24,7 @@ import static org.junit.Assert.assertEquals;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.avanza.astrix.beans.publish.ApiProviderClass;
@@ -38,8 +37,8 @@ public class AstrixApiProviderClassScannerTest {
 	public void scansDefinedPackagesForDefinedAnnotations() throws Exception {
 		List<ApiProviderClass> apiDescriptors = new AstrixApiProviderClassScanner(asList(DummyDescriptor.class), "com.avanza.astrix.context").getAll().collect(toList());
 		assertEquals(2, apiDescriptors.size());
-		Assert.assertThat(apiDescriptors, hasItem(equalTo(ApiProviderClass.create(DescriptorA.class))));
-		Assert.assertThat(apiDescriptors, hasItem(equalTo(ApiProviderClass.create(DescriptorB.class))));
+		assertThat(apiDescriptors, hasItem(equalTo(ApiProviderClass.create(DescriptorA.class))));
+		assertThat(apiDescriptors, hasItem(equalTo(ApiProviderClass.create(DescriptorB.class))));
 	}
 	
 	@Test

--- a/astrix-context/src/test/java/com/avanza/astrix/context/AstrixContextImplTest.java
+++ b/astrix-context/src/test/java/com/avanza/astrix/context/AstrixContextImplTest.java
@@ -15,7 +15,7 @@
  */
 package com.avanza.astrix.context;
 
-import static junit.framework.Assert.assertSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/astrix-context/src/test/java/com/avanza/astrix/context/metrics/BeanMetricsTest.java
+++ b/astrix-context/src/test/java/com/avanza/astrix/context/metrics/BeanMetricsTest.java
@@ -134,7 +134,7 @@ public class BeanMetricsTest {
 
 		@Override
 		public Observable<String> observePing(final String msg) {
-			return Observable.create(t -> {
+			return Observable.unsafeCreate(t -> {
 				fakeClock.incrementAndGet(); // Simulate 2 ms execution time by ticking clock
 				fakeClock.incrementAndGet();
 				t.onNext(msg);

--- a/astrix-contracts/src/main/java/com/avanza/astrix/contracts/ReactiveTypeHandlerContract.java
+++ b/astrix-contracts/src/main/java/com/avanza/astrix/contracts/ReactiveTypeHandlerContract.java
@@ -101,7 +101,7 @@ public abstract class ReactiveTypeHandlerContract<T> {
 	@Test(timeout=1000)
 	public final void reactiveTypeToObservable_CreatedObserverIsSubscribedInConversion() throws Exception {
 		AtomicInteger sourceSubscriptionCount = new AtomicInteger(0);
-		Observable<Object> emitsFoo = Observable.create((s) -> {
+		Observable<Object> emitsFoo = Observable.unsafeCreate((s) -> {
 			sourceSubscriptionCount.incrementAndGet();
 			s.onNext("foo");
 			s.onCompleted();
@@ -120,7 +120,7 @@ public abstract class ReactiveTypeHandlerContract<T> {
 	@Test
 	public final void onlySubscribesOneTimeToSourceObservableIfConvertingBackAndForth() throws Exception {
 		AtomicInteger sourceSubscriptionCount = new AtomicInteger(0);
-		Observable<Object> emitsFoo = Observable.create((s) -> {
+		Observable<Object> emitsFoo = Observable.unsafeCreate((s) -> {
 			sourceSubscriptionCount.incrementAndGet();
 			s.onNext("foo");
 			s.onCompleted();
@@ -154,6 +154,7 @@ public abstract class ReactiveTypeHandlerContract<T> {
 		assertEquals("foo", resultSpy.error.getMessage());
 	}
 
+	@SuppressWarnings("unchecked")
 	private T toCustomReactiveType(Observable<Object> emitsFoo) {
 		return (T) reactiveTypeConverter.toCustomReactiveType(reactiveType(), emitsFoo);
 	}

--- a/astrix-core/src/main/java/com/avanza/astrix/core/util/ReflectionUtil.java
+++ b/astrix-core/src/main/java/com/avanza/astrix/core/util/ReflectionUtil.java
@@ -47,8 +47,8 @@ public class ReflectionUtil {
 	
 	public static <T> T newInstance(Class<T> type) {
 		try {
-			return type.newInstance();
-		} catch (InstantiationException | IllegalAccessException e) {
+			return type.getDeclaredConstructor().newInstance();
+		} catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 			throw new RuntimeException("Failed to instantiate class: " + type.getName(), e);
 		}
 	}

--- a/astrix-core/src/test/java/com/avanza/astrix/core/util/GenericAstrixSetReducerTest.java
+++ b/astrix-core/src/test/java/com/avanza/astrix/core/util/GenericAstrixSetReducerTest.java
@@ -16,7 +16,7 @@
 package com.avanza.astrix.core.util;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;

--- a/astrix-fault-tolerance/src/test/java/com/avanza/astrix/ft/hystrix/FaultToleranceThroughputTest.java
+++ b/astrix-fault-tolerance/src/test/java/com/avanza/astrix/ft/hystrix/FaultToleranceThroughputTest.java
@@ -369,7 +369,7 @@ public class FaultToleranceThroughputTest {
 
 		@Override
 		public Observable<String> observeServiceCall() {
-			return Observable.create((subscriber) -> {
+			return Observable.unsafeCreate((subscriber) -> {
 				exec.execute(() -> {
 					try {
 						subscriber.onNext(serviceCall());

--- a/astrix-fault-tolerance/src/test/java/com/avanza/astrix/ft/hystrix/HystrixObservableCommandFacadeTest.java
+++ b/astrix-fault-tolerance/src/test/java/com/avanza/astrix/ft/hystrix/HystrixObservableCommandFacadeTest.java
@@ -147,7 +147,7 @@ public class HystrixObservableCommandFacadeTest {
 	
 	@Test
 	public void throwsServiceUnavailableOnTimeouts() throws Exception {
-		pingServer.setResult(Observable.create(new OnSubscribe<String>() {
+		pingServer.setResult(Observable.unsafeCreate(new OnSubscribe<String>() {
 			@Override
 			public void call(Subscriber<? super String> t1) {
 				// Simulate timeout by not invoking subscriber
@@ -168,7 +168,7 @@ public class HystrixObservableCommandFacadeTest {
 	
 	@Test
 	public void semaphoreRejectedCountsAsFailure() throws Exception {
-		pingServer.setResult(Observable.create(new OnSubscribe<String>() {
+		pingServer.setResult(Observable.unsafeCreate(new OnSubscribe<String>() {
 			@Override
 			public void call(Subscriber<? super String> t1) {
 				// Simulate timeout by not invoking subscriber
@@ -193,7 +193,7 @@ public class HystrixObservableCommandFacadeTest {
 		Supplier<Observable<String>> timeoutCommandSupplier = new Supplier<Observable<String>>() {
 			@Override
 			public Observable<String> get() {
-				return Observable.create(t1 -> {
+				return Observable.unsafeCreate(t1 -> {
 					subscribed.set(true);
 				});
 			}
@@ -210,7 +210,7 @@ public class HystrixObservableCommandFacadeTest {
 			@Override
 			public Observable<String> get() {
 				supplierInvocationCount.incrementAndGet();
-				return Observable.create(new OnSubscribe<String>() {
+				return Observable.unsafeCreate(new OnSubscribe<String>() {
 					@Override
 					public void call(Subscriber<? super String> t1) {
 						// Simulate timeout by not invoking subscriber

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/AsyncFutureTypeHandler.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/AsyncFutureTypeHandler.java
@@ -59,7 +59,8 @@ public class AsyncFutureTypeHandler implements ReactiveTypeHandlerPlugin<AsyncFu
 	public AsyncFuture<Object> newReactiveType() {
 		return new AsyncFutureImpl<>();
 	}
-	
+
+	@SuppressWarnings("unchecked")
 	@Override
 	public Class<AsyncFuture<Object>> reactiveTypeHandled() {
 		Class<?> class1 = AsyncFuture.class;

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/GsBinder.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/GsBinder.java
@@ -21,11 +21,11 @@ import java.util.regex.Pattern;
 import org.openspaces.core.GigaSpace;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.context.ApplicationContext;
+
 import com.avanza.astrix.beans.core.AstrixConfigAware;
 import com.avanza.astrix.beans.core.AstrixSettings;
 import com.avanza.astrix.beans.service.ServiceProperties;
 import com.avanza.astrix.config.DynamicConfig;
-import com.j_spaces.core.client.SpaceURL;
 
 /**
  * 

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/GsBinder.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/GsBinder.java
@@ -117,7 +117,7 @@ public class GsBinder implements AstrixConfigAware {
 		private String versioned;
 		
 		public SpaceUrlBuilder(GigaSpace space) {
-			SpaceURL finderURL = space.getSpace().getFinderURL();
+			var finderURL = space.getSpace().getFinderURL();
 			this.locators = finderURL.getProperty("locators");
 			this.groups = finderURL.getProperty("groups");
 			this.versioned = Boolean.toString(space.getSpace().isOptimisticLockingEnabled());

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/SpaceTaskDispatcher.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/SpaceTaskDispatcher.java
@@ -129,6 +129,7 @@ public final class SpaceTaskDispatcher {
 		}));
 	}
 
+	@SuppressWarnings("deprecation")
 	private <T extends Serializable> void submitRoutedTaskExecution(Subscriber<? super T> subscriber, final Task<T> task, final Object routingKey) {
 		usingErrorReporter(subscriber, serviceUnavailable()).accept(() -> {
 			// Submit task on current thread in executorService
@@ -145,19 +146,19 @@ public final class SpaceTaskDispatcher {
 	/**
 	 * Creates a lazy Observable that will execute a given DistributedTask asynchronously once subscribed to.
 	 * 
-	 * @param task
-	 * @param routingKey
+	 * @param distributedTask
 	 * @return
 	 */
 	public <T extends Serializable, R> Observable<R> observe(final DistributedTask<T, R> distributedTask) {
-		return Observable.create(t1 -> {
+		return Observable.unsafeCreate(t1 -> {
 			Runnable command = contextPropagation.wrap(() -> submitDistributedTaskExecution(distributedTask, t1));
 			usingErrorReporter(t1, serviceUnavailable()).accept(() -> {
 				executorService.execute(command);
 			});
 		});
 	}
-	
+
+	@SuppressWarnings("deprecation")
 	private <R, T extends Serializable> void submitDistributedTaskExecution(final DistributedTask<T, R> distributedTask, Subscriber<? super R> t1) {
 		usingErrorReporter(t1, serviceUnavailable()).accept(() -> {
 			// Submit task on current thread in executorService

--- a/astrix-gs/src/main/java/com/avanza/astrix/gs/localview/GsLocalViewComponent.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/gs/localview/GsLocalViewComponent.java
@@ -103,10 +103,11 @@ public class GsLocalViewComponent implements ServiceComponent, AstrixConfigAware
 		
 		IJSpace localViewSpace = gslocalViewSpaceConfigurer.create();
 		GigaSpace localViewGigaSpace = GigaSpaceProxy.create(new GigaSpaceConfigurer(localViewSpace).create());
-		
-		BoundLocalViewGigaSpaceBeanInstance localViewGigaSpaceBeanInstance = 
-				new BoundLocalViewGigaSpaceBeanInstance(localViewGigaSpace, gslocalViewSpaceConfigurer, gsSpaceConfigurer);
-		return (BoundServiceBeanInstance<T>) localViewGigaSpaceBeanInstance;
+
+		@SuppressWarnings("unchecked")
+		BoundServiceBeanInstance<T> localViewGigaSpaceBeanInstance =
+				(BoundServiceBeanInstance<T>) new BoundLocalViewGigaSpaceBeanInstance(localViewGigaSpace, gslocalViewSpaceConfigurer, gsSpaceConfigurer);
+		return localViewGigaSpaceBeanInstance;
 	}
 	
 	@Override

--- a/astrix-gs/src/main/java/com/avanza/astrix/remoting/util/GsUtil.java
+++ b/astrix-gs/src/main/java/com/avanza/astrix/remoting/util/GsUtil.java
@@ -96,7 +96,7 @@ public class GsUtil {
 		return new Func1<List<AsyncResult<T>>, Observable<T>>() {
 			@Override
 			public Observable<T> call(final List<AsyncResult<T>> asyncRresults) {
-				return Observable.create(new OnSubscribe<T>() {
+				return Observable.unsafeCreate(new OnSubscribe<T>() {
 					@Override
 					public void call(Subscriber<? super T> subscriber) {
 						for (AsyncResult<T> asyncInvocationResponse : asyncRresults) {

--- a/astrix-gs/src/test/java/com/avanza/astrix/remoting/util/GsUtilTest.java
+++ b/astrix-gs/src/test/java/com/avanza/astrix/remoting/util/GsUtilTest.java
@@ -16,13 +16,13 @@
 package com.avanza.astrix.remoting.util;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.junit.Test;
+
 import com.avanza.astrix.beans.async.ContextPropagation;
 import com.gigaspaces.async.AsyncResult;
 import com.gigaspaces.async.SettableFuture;

--- a/astrix-http/src/main/java/com/avanza/astrix/http/HttpRemotingTransport.java
+++ b/astrix-http/src/main/java/com/avanza/astrix/http/HttpRemotingTransport.java
@@ -67,7 +67,7 @@ public final class HttpRemotingTransport implements RemotingTransportSpi {
 		ClusterMember clusterMember = getTargetMember(routingKey);
 		final HttpPost postRequest = new HttpPost(clusterMember.getRemoteEndpointUri());
 		postRequest.setEntity(new SerializableEntity(request));
-		return Observable.create(new OnSubscribe<AstrixServiceInvocationResponse>() {
+		return Observable.unsafeCreate(new OnSubscribe<AstrixServiceInvocationResponse>() {
 			@Override
 			public void call(final Subscriber<? super AstrixServiceInvocationResponse> t1) {
 				try {
@@ -97,7 +97,7 @@ public final class HttpRemotingTransport implements RemotingTransportSpi {
 		for (ClusterMember clusterMember : getAllClusterMembers()) {
 			final HttpPost postRequest = new HttpPost(clusterMember.getRemoteEndpointUri());
 			postRequest.setEntity(new SerializableEntity(request));
-			result = result.mergeWith(Observable.create(new OnSubscribe<AstrixServiceInvocationResponse>() {
+			result = result.mergeWith(Observable.unsafeCreate(new OnSubscribe<AstrixServiceInvocationResponse>() {
 				@Override
 				public void call(final Subscriber<? super AstrixServiceInvocationResponse> t1) {
 					try {

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/AstrixIntegrationTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/AstrixIntegrationTest.java
@@ -18,11 +18,11 @@ package com.avanza.astrix.integration.tests;
 import static com.avanza.astrix.integration.tests.TestLunchRestaurantBuilder.lunchRestaurant;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 import java.util.List;
 import java.util.Properties;
@@ -37,6 +37,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openspaces.core.GigaSpace;
+
 import com.avanza.astrix.beans.core.AstrixBeanKey;
 import com.avanza.astrix.beans.core.AstrixSettings;
 import com.avanza.astrix.beans.registry.AstrixServiceRegistry;

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/GigaSpacesAuthenticationTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/GigaSpacesAuthenticationTest.java
@@ -16,7 +16,7 @@
 package com.avanza.astrix.integration.tests;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.Properties;

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/GsBinderIntegrationTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/GsBinderIntegrationTest.java
@@ -40,7 +40,7 @@ public class GsBinderIntegrationTest {
 	
 	@After
 	public void closeContext() {
-		applicationContext.destroy(); 
+		applicationContext.close();
 	}
 
 	@Test

--- a/astrix-metrics/src/test/java/com/avanza/astrix/metrics/DropwizardMetricsTest.java
+++ b/astrix-metrics/src/test/java/com/avanza/astrix/metrics/DropwizardMetricsTest.java
@@ -17,7 +17,7 @@ package com.avanza.astrix.metrics;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.function.Supplier;
 

--- a/astrix-modules/src/main/java/com/avanza/astrix/modules/ClassConstructorFactory.java
+++ b/astrix-modules/src/main/java/com/avanza/astrix/modules/ClassConstructorFactory.java
@@ -81,6 +81,7 @@ final class ClassConstructorFactory<T> {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	private static <E> Class<E> getElementType(ParameterizedType listType) {
 		Type actualTypeArguments = listType.getActualTypeArguments()[0];
 		if (actualTypeArguments instanceof Class) {
@@ -90,6 +91,7 @@ final class ClassConstructorFactory<T> {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	private Constructor<T> getFactory() {
 		Constructor<?>[] constructors = factory.getDeclaredConstructors();
 		if (constructors.length == 0) {

--- a/astrix-modules/src/main/java/com/avanza/astrix/modules/ModuleInjector.java
+++ b/astrix-modules/src/main/java/com/avanza/astrix/modules/ModuleInjector.java
@@ -82,11 +82,13 @@ class ModuleInjector {
 				}
 			});
 		}
-		
+
 		public <T> Class<T> resolveBean(Class<T> type) {
 			Class<?> boundType = beanBindings.get(type);
 			if (boundType != null) {
-				return (Class<T>) boundType;
+				@SuppressWarnings("unchecked")
+				var castedBoundType = (Class<T>) boundType;
+				return castedBoundType;
 			}
 			if (Modifier.isAbstract(type.getModifiers()) || type.isInterface()) {
 				throw new MissingBeanBinding(moduleName, type, constructionStack);

--- a/astrix-modules/src/test/java/com/avanza/astrix/modules/test/ModulesTest.java
+++ b/astrix-modules/src/test/java/com/avanza/astrix/modules/test/ModulesTest.java
@@ -17,10 +17,10 @@ package com.avanza.astrix.modules.test;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
 import java.util.List;

--- a/astrix-netty-remoting/src/main/java/com/avanza/astrix/netty/client/NettyRemotingClientHandler.java
+++ b/astrix-netty-remoting/src/main/java/com/avanza/astrix/netty/client/NettyRemotingClientHandler.java
@@ -73,7 +73,7 @@ public class NettyRemotingClientHandler extends ChannelInboundHandlerAdapter {
     }
 
 	public Observable<AstrixServiceInvocationResponse> sendInvocationRequest(AstrixServiceInvocationRequest request) {
-		return Observable.create((subscriber) -> {
+		return Observable.unsafeCreate((subscriber) -> {
 			String invocationId = UUID.randomUUID().toString();
 			this.subscriberBySubscriberId.put(invocationId, subscriber);
 			request.setHeader(NETTY_RESPONSE_SUBSCRIBER_ID, invocationId);

--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/BroadcastedRemoteServiceMethod.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/BroadcastedRemoteServiceMethod.java
@@ -19,12 +19,11 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
-import rx.Observable;
-import rx.functions.Func1;
-
 import com.avanza.astrix.core.AstrixRemoteResult;
 import com.avanza.astrix.core.RemoteResultReducer;
 import com.avanza.astrix.core.util.ReflectionUtil;
+
+import rx.Observable;
 
 /**
  * 
@@ -66,6 +65,7 @@ public class BroadcastedRemoteServiceMethod implements RemoteServiceMethod {
 			AstrixServiceInvocationRequest request, Object[] args) throws InstantiationException,
 			IllegalAccessException {
 		request.setArguments(remotingEngine.marshall(args));
+		@SuppressWarnings("unchecked")
 		final RemoteResultReducer<T> reducer = (RemoteResultReducer<T>) newReducer();
 		Observable<List<AstrixServiceInvocationResponse>> responesObservable = remotingEngine.submitBroadcastRequest(request);
 		if (returnType.equals(Void.TYPE) || returnType.equals(Void.class)) {

--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/PartitionedRemoteServiceMethod.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/PartitionedRemoteServiceMethod.java
@@ -84,6 +84,7 @@ public class PartitionedRemoteServiceMethod implements RemoteServiceMethod {
 		if (partitionedArgumentType.isArray()) {
 			return new ArrayContainerType(partitionedArgumentType.getComponentType());
 		}
+		@SuppressWarnings("unchecked")
 		Class<? extends Collection<?>> collectionFactory = (Class<? extends Collection<?>>) partitionBy.collectionFactory();
 		if (!proxiedMethod.getParameterTypes()[partitionedArgumentIndex].isAssignableFrom(collectionFactory)) {
 			throw new IllegalArgumentException(String.format("Collection class supplied by @AstrixPartitionedRouting is not "
@@ -100,6 +101,7 @@ public class PartitionedRemoteServiceMethod implements RemoteServiceMethod {
 	}
 
 	private Class<? extends RemoteResultReducer<?>> getReducer(AstrixPartitionedRouting partitionBy, Method targetServiceMethod) {
+		@SuppressWarnings("unchecked")
 		Class<? extends RemoteResultReducer<?>> reducerType = (Class<? extends RemoteResultReducer<?>>) partitionBy.reducer();
 		RemotingProxyUtil.validateRemoteResultReducer(targetServiceMethod, reducerType);
 		return reducerType;
@@ -245,6 +247,7 @@ public class PartitionedRemoteServiceMethod implements RemoteServiceMethod {
 			this.elementType = Objects.requireNonNull(elementType);
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public ContainerBuilder newInstance() {
 			return new CollectionContainerBuilder((Collection<? super Object>) ReflectionUtil.newInstance(this.collectionFactory));

--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/RemoteServiceMethodFactory.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/RemoteServiceMethodFactory.java
@@ -87,6 +87,7 @@ public class RemoteServiceMethodFactory {
 
 	private Class<? extends RemoteResultReducer<?>> getRemoteResultReducerClass( Method targetServiceMethod) {
 		AstrixBroadcast broadcast = targetServiceMethod.getAnnotation(AstrixBroadcast.class);
+		@SuppressWarnings("unchecked")
 		Class<? extends RemoteResultReducer<?>> reducerType = (Class<? extends RemoteResultReducer<?>>) broadcast.reducer();
 		RemotingProxyUtil.validateRemoteResultReducer(targetServiceMethod, reducerType);
 		return reducerType;

--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/RemotingEngine.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/RemotingEngine.java
@@ -68,7 +68,10 @@ public final class RemotingEngine {
 		}
 		ParameterizedType optionalType = ParameterizedType.class.cast(returnType);
 		Object result = unmarshall(response, optionalType.getActualTypeArguments()[0], apiVersion);
-		return (T) Optional.ofNullable(result);
+
+		@SuppressWarnings("unchecked")
+		T castedResult = (T) Optional.ofNullable(result);
+		return castedResult;
 	}
 
 	// Defines whether the service invocation returned the value 'null' (as opposed to Optional.empty()).

--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/RemotingProxy.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/client/RemotingProxy.java
@@ -83,6 +83,7 @@ public class RemotingProxy implements InvocationHandler {
 			AstrixTraceProvider astrixTraceProvider
 	) {
 		RemotingProxy handler = new RemotingProxy(proxyApi, targetApi, objectSerializer, transport, defaultRoutingStrategy, reactiveTypeConverter, astrixTraceProvider);
+		@SuppressWarnings("unchecked")
 		T serviceProxy = (T) Proxy.newProxyInstance(RemotingProxy.class.getClassLoader(), new Class[]{proxyApi}, handler);
 		return serviceProxy;
 	}

--- a/astrix-remoting/src/main/java/com/avanza/astrix/remoting/server/AstrixServiceActivatorImpl.java
+++ b/astrix-remoting/src/main/java/com/avanza/astrix/remoting/server/AstrixServiceActivatorImpl.java
@@ -19,6 +19,21 @@ import static com.avanza.astrix.remoting.client.AstrixServiceInvocationRequestHe
 import static com.avanza.astrix.remoting.client.AstrixServiceInvocationRequestHeaders.SERVICE_API;
 import static com.avanza.astrix.remoting.client.AstrixServiceInvocationRequestHeaders.SERVICE_METHOD_SIGNATURE;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.avanza.astrix.beans.config.AstrixConfig;
 import com.avanza.astrix.beans.core.AstrixSettings;
 import com.avanza.astrix.beans.tracing.AstrixTraceProvider;
@@ -36,20 +51,6 @@ import com.avanza.astrix.remoting.client.AstrixServiceInvocationResponse;
 import com.avanza.astrix.remoting.client.AstrixServiceInvocationResponseHeaders;
 import com.avanza.astrix.remoting.client.MissingServiceMethodException;
 import com.avanza.astrix.versioning.core.AstrixObjectSerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 /**
  * Server side component used to invoke exported services. <p> 
  * 
@@ -175,7 +176,9 @@ class AstrixServiceActivatorImpl implements AstrixServiceActivator {
 				if (result == null) {
 					invocationResponse.setHeader(AstrixServiceInvocationResponseHeaders.OPTIONAL_RETURN_VALUE_IS_NULL, "true");
 				} else {
-					invocationResponse.setResponseBody(objectSerializer.serialize(Optional.class.cast(result).orElse(null), version));
+					@SuppressWarnings("unchecked")
+					var cast = Optional.class.cast(result).orElse(null);
+					invocationResponse.setResponseBody(objectSerializer.serialize(cast, version));
 				}
 			} else {
 				invocationResponse.setResponseBody(objectSerializer.serialize(result, version));

--- a/astrix-remoting/src/test/java/com/avanza/astrix/remoting/server/AstrixRemotingDriver.java
+++ b/astrix-remoting/src/test/java/com/avanza/astrix/remoting/server/AstrixRemotingDriver.java
@@ -152,7 +152,7 @@ public class AstrixRemotingDriver {
 		@Override
 		public Observable<AstrixServiceInvocationResponse> submitRoutedRequest(AstrixServiceInvocationRequest request, RoutingKey routingKey){
 			final AstrixServiceInvocationResponse response = getActivator(routingKey).invokeService(request);
-			return Observable.create(new Observable.OnSubscribe<AstrixServiceInvocationResponse>() {
+			return Observable.unsafeCreate(new Observable.OnSubscribe<AstrixServiceInvocationResponse>() {
 				@Override
 				public void call(Subscriber<? super AstrixServiceInvocationResponse> t1) {
 					t1.onNext(response);
@@ -171,7 +171,7 @@ public class AstrixRemotingDriver {
 			for (AstrixServiceActivatorImpl partition : partitions) {
 				responses.add(partition.invokeService(request));
 			}
-			return Observable.create(new Observable.OnSubscribe<AstrixServiceInvocationResponse>() {
+			return Observable.unsafeCreate(new Observable.OnSubscribe<AstrixServiceInvocationResponse>() {
 				@Override
 				public void call(Subscriber<? super AstrixServiceInvocationResponse> t1) {
 					for (AstrixServiceInvocationResponse r : responses) {

--- a/astrix-remoting/src/test/java/com/avanza/astrix/remoting/server/AstrixRemotingTest.java
+++ b/astrix-remoting/src/test/java/com/avanza/astrix/remoting/server/AstrixRemotingTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.Serializable;
@@ -272,7 +272,7 @@ public class AstrixRemotingTest {
 
 		PartitionedPingService partitionedPing = remotingDriver.createRemotingProxy(PartitionedPingService.class, PartitionedPingService.class); 
 		partitionedPing.pingVoid(new Integer[]{});
-		Mockito.verifyZeroInteractions(evenPartitionPing, oddPartitionPing);
+		Mockito.verifyNoInteractions(evenPartitionPing, oddPartitionPing);
 	}
 	
 	@Test(expected = RemoteServiceInvocationException.class)
@@ -406,6 +406,7 @@ public class AstrixRemotingTest {
 		assertEquals(setOf(1,2,3), calculatorService.ping(setOf(1,2,3)));
 	}
 	
+	@SafeVarargs
 	private static <T> Set<T> setOf(@SuppressWarnings("unchecked") T... values) {
 		return new HashSet<T>(Arrays.asList(values));
 	}

--- a/astrix-remoting/src/test/java/com/avanza/astrix/remoting/server/RemotingTracingTest.java
+++ b/astrix-remoting/src/test/java/com/avanza/astrix/remoting/server/RemotingTracingTest.java
@@ -17,9 +17,9 @@ package com.avanza.astrix.remoting.server;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/astrix-test-support/src/main/java/com/avanza/astrix/test/ServiceInvocationExceptionTestBase.java
+++ b/astrix-test-support/src/main/java/com/avanza/astrix/test/ServiceInvocationExceptionTestBase.java
@@ -23,8 +23,8 @@ import java.lang.reflect.Method;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * Extend this test-class in order to test that your RuntimeExceptions are Astrix ready.

--- a/astrix-test-support/src/main/java/com/avanza/astrix/test/TestApis.java
+++ b/astrix-test-support/src/main/java/com/avanza/astrix/test/TestApis.java
@@ -18,6 +18,7 @@ package com.avanza.astrix.test;
 import com.avanza.astrix.beans.core.AstrixBeanKey;
 import com.avanza.astrix.test.TestApi.TestContext;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -62,8 +63,8 @@ final class TestApis {
 
 	private TestApi initTestApi(Class<? extends TestApi> testApiType) {
 		try {
-			return testApiType.newInstance();
-		} catch (InstantiationException | IllegalAccessException e) {
+			return testApiType.getDeclaredConstructor().newInstance();
+		} catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 			throw new RuntimeException("Failed to instantiate TestApi: " + testApiType.getName(), e);
 		}
 	}

--- a/astrix-versioning/src/main/java/com/avanza/astrix/versioning/core/AstrixObjectSerializer.java
+++ b/astrix-versioning/src/main/java/com/avanza/astrix/versioning/core/AstrixObjectSerializer.java
@@ -44,7 +44,8 @@ public interface AstrixObjectSerializer {
 	public static class NoVersioningSupport implements AstrixObjectSerializer {
 		
 		public static final int NO_VERSIONING = -21;
-		
+
+		@SuppressWarnings("unchecked")
 		@Override
 		public <T> T deserialize(Object element, Type type, int version) {
 			return (T) element;

--- a/astrix-versioning/src/main/java/com/avanza/astrix/versioning/jackson2/Jackson2AstrixObjectSerializer.java
+++ b/astrix-versioning/src/main/java/com/avanza/astrix/versioning/jackson2/Jackson2AstrixObjectSerializer.java
@@ -31,7 +31,7 @@ class Jackson2AstrixObjectSerializer implements AstrixObjectSerializer {
 		Class<? extends AstrixObjectSerializerConfigurer> serializerBuilder = serializerDefinition.getObjectSerializerConfigurerClass();
 		this.version = serializerDefinition.version();
 		try {
-			this.objectMapper = buildObjectMapper(Jackson2ObjectSerializerConfigurer.class.cast(serializerBuilder.newInstance()));
+			this.objectMapper = buildObjectMapper(Jackson2ObjectSerializerConfigurer.class.cast(serializerBuilder.getDeclaredConstructor().newInstance()));
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to init JsonObjectMapper", e);
 		}
@@ -46,7 +46,9 @@ class Jackson2AstrixObjectSerializer implements AstrixObjectSerializer {
 	@Override
 	public <T> T deserialize(Object element, Type type, int fromVersion) {
 		if (fromVersion == NoVersioningSupport.NO_VERSIONING) {
-			return (T) element;
+			@SuppressWarnings("unchecked")
+			T castedElement = (T) element;
+			return castedElement;
 		}
 		return objectMapper.deserialize((String) element, type, fromVersion);
 	}

--- a/astrix-versioning/src/main/java/com/avanza/astrix/versioning/jackson2/VersionedJsonObjectMapper.java
+++ b/astrix-versioning/src/main/java/com/avanza/astrix/versioning/jackson2/VersionedJsonObjectMapper.java
@@ -254,7 +254,7 @@ public class VersionedJsonObjectMapper implements JsonObjectMapper.Impl {
 		}
 
 		private ObjectMapper buildRaw() {
-			SimpleModule rawModule = new SimpleModule("Astrix-rawModule", new Version(1,0,0, "", "", ""));
+			SimpleModule rawModule = new SimpleModule("Astrix-rawModule", new Version(1,0,0, "", null, null));
 			for (JsonDeserializerHolder<?> deserializer : this.deserializers) {
 				deserializer.register(rawModule);
 			}

--- a/astrix-versioning/src/main/java/com/avanza/astrix/versioning/jackson2/VersionedJsonObjectMapper.java
+++ b/astrix-versioning/src/main/java/com/avanza/astrix/versioning/jackson2/VersionedJsonObjectMapper.java
@@ -177,6 +177,7 @@ public class VersionedJsonObjectMapper implements JsonObjectMapper.Impl {
 		}
 
 		<T> void register(int version, AstrixJsonMessageMigration<T> messageMigration) {
+			@SuppressWarnings("unchecked")
 			Builder<T> builder = (Builder<T>) buildersByType.get(messageMigration.getJavaType());
 			if (builder == null) {
 				builder = new Builder<>(messageMigration.getJavaType());
@@ -253,7 +254,7 @@ public class VersionedJsonObjectMapper implements JsonObjectMapper.Impl {
 		}
 
 		private ObjectMapper buildRaw() {
-			SimpleModule rawModule = new SimpleModule("Astrix-rawModule", new Version(1,0,0, ""));
+			SimpleModule rawModule = new SimpleModule("Astrix-rawModule", new Version(1,0,0, "", "", ""));
 			for (JsonDeserializerHolder<?> deserializer : this.deserializers) {
 				deserializer.register(rawModule);
 			}


### PR DESCRIPTION
* One Observable create method has been deprecated. It is however identical to the unsafeCreate method and has been replaced.
* clazz.newInstance has been deprecated and replaced with clazz.getDeclaredConstructor().newInstance() according to javadoc instructions.
* AstrixSettings class is deprecated but was missing the tag.
* Unchecked cast warnings were suppressed.
* jUnit assertThat has been deprecated. Replaced with method in hamcrest.
* Mockito.verifyZeroInteractions has been deprecated. Replaced with verifyNoInteractions.
* Deprecated constructor in Jackson Version was replaced.
* Destroy method is deprecated. Replaced with close method.
* SafeVarargs annotation added to AstrixRemotingTest to get rid of possible heap solution warning.