### PR TITLE
Remove Guava

### DIFF
--- a/astrix-context/src/main/java/com/avanza/astrix/context/AstrixApiProviderClassScanner.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/context/AstrixApiProviderClassScanner.java
@@ -15,20 +15,25 @@
  */
 package com.avanza.astrix.context;
 
-import com.avanza.astrix.beans.publish.ApiProviderClass;
-import com.avanza.astrix.beans.publish.ApiProviders;
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toList;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Stream;
+
 import org.reflections.Reflections;
 import org.reflections.ReflectionsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.annotation.Annotation;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
-
-import static java.util.Collections.emptySet;
-import static java.util.stream.Collectors.toList;
+import com.avanza.astrix.beans.publish.ApiProviderClass;
+import com.avanza.astrix.beans.publish.ApiProviders;
 
 /**
  * Uses classpath scanning to find api-providers. <p>
@@ -38,9 +43,9 @@ import static java.util.stream.Collectors.toList;
  */
 public class AstrixApiProviderClassScanner implements ApiProviders {
 
-	private final Logger log = LoggerFactory.getLogger(AstrixApiProviderClassScanner.class);
+	private static final Logger log = LoggerFactory.getLogger(AstrixApiProviderClassScanner.class);
 	
-	private static final Map<String, List<ApiProviderClass>> apiProvidersByBasePackage = new ConcurrentHashMap<>();
+	private static final ConcurrentMap<String, List<ApiProviderClass>> apiProvidersByBasePackage = new ConcurrentHashMap<>();
 	private final List<String> basePackages = new ArrayList<>();
 	private final List<Class<? extends Annotation>> providerAnnotationsToScanFor;
 	
@@ -84,7 +89,7 @@ public class AstrixApiProviderClassScanner implements ApiProviders {
 		return providerAnnotationsToScanFor;
 	}
 
-	private Set<Class<?>> getTypesAnnotatedWith(Reflections reflections, Class<? extends Annotation> annotation) {
+	private static Set<Class<?>> getTypesAnnotatedWith(Reflections reflections, Class<? extends Annotation> annotation) {
 		try {
 			return reflections.getTypesAnnotatedWith(annotation);
 		} catch (ReflectionsException exception) {

--- a/astrix-fault-tolerance/pom.xml
+++ b/astrix-fault-tolerance/pom.xml
@@ -36,11 +36,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>astrix-test-util</artifactId>
 			<version>${project.version}</version>

--- a/astrix-gs/pom.xml
+++ b/astrix-gs/pom.xml
@@ -39,9 +39,10 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<scope>test</scope>
+			<!-- @GuardedBy, only used at compile time -->
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -53,15 +54,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.gigaspaces</groupId>
-			<artifactId>xap-openspaces</artifactId>			
+			<artifactId>xap-openspaces</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.gigaspaces</groupId>
-			<artifactId>xap-near-cache-spring</artifactId>			
+			<artifactId>xap-near-cache-spring</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.gigaspaces</groupId>
-			<artifactId>xap-datagrid</artifactId>			
+			<artifactId>xap-datagrid</artifactId>
 		</dependency>
 
 		<!-- TEST -->
@@ -73,6 +74,11 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/astrix-versioning/pom.xml
+++ b/astrix-versioning/pom.xml
@@ -24,10 +24,5 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 </project>

--- a/astrix-versioning/src/test/java/com/avanza/astrix/versioning/jackson2/VersionedJsonObjectMapperTest.java
+++ b/astrix-versioning/src/test/java/com/avanza/astrix/versioning/jackson2/VersionedJsonObjectMapperTest.java
@@ -15,22 +15,22 @@
  */
 package com.avanza.astrix.versioning.jackson2;
 
-import static org.junit.Assert.assertEquals;
+import com.avanza.astrix.versioning.jackson2.VersionedJsonObjectMapper.VersionedObjectMapperBuilder;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import com.avanza.astrix.versioning.jackson2.VersionedJsonObjectMapper.VersionedObjectMapperBuilder;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.reflect.TypeToken;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 
 
 public class VersionedJsonObjectMapperTest {
 	
 	List<AstrixJsonApiMigration> apiMigrations = new ArrayList<>();
-	
+
 	@Test
 	public void canSerializerAndDeserializeObjectsUsingObjectMapper() throws Exception {
 		VersionedObjectMapperBuilder objectMapperBuilder = new VersionedObjectMapperBuilder(apiMigrations);
@@ -75,7 +75,6 @@ public class VersionedJsonObjectMapperTest {
 	}
 	
 	@Test
-	@SuppressWarnings("serial")
 	public void deserializesGenericTypes() throws Exception {
 		VersionedObjectMapperBuilder objectMapperBuilder = new VersionedObjectMapperBuilder(apiMigrations);
 		VersionedJsonObjectMapper objectMapper = objectMapperBuilder.build();
@@ -85,7 +84,7 @@ public class VersionedJsonObjectMapperTest {
 		testPojos.add(testPojo1);
 		String jsonPojo = objectMapper.serialize(testPojos, 1);
 		
-		TypeToken<List<TestPojoV1>> genericListType = new TypeToken<List<TestPojoV1>>() {};
+		TypeReference<List<TestPojoV1>> genericListType = new TypeReference<>() {};
 		
 		List<TestPojoV1> deserializedPojos = objectMapper.deserialize(jsonPojo, genericListType.getType(), 1);
 		assertEquals(1, deserializedPojos.size());
@@ -93,7 +92,6 @@ public class VersionedJsonObjectMapperTest {
 	}
 
 	@Test
-	@SuppressWarnings("serial")
 	public void migratesGenericTypes() throws Exception {
 		apiMigrations.add(new TestPojoV1ToV2Migration());
 		VersionedObjectMapperBuilder objectMapperBuilder = new VersionedObjectMapperBuilder(apiMigrations);
@@ -104,7 +102,7 @@ public class VersionedJsonObjectMapperTest {
 		testPojos.add(testPojo1);
 		String jsonPojo = objectMapper.serialize(testPojos, 1);
 		
-		TypeToken<List<TestPojoV2>> genericListType = new TypeToken<List<TestPojoV2>>() {};
+		TypeReference<List<TestPojoV2>> genericListType = new TypeReference<>() {};
 		
 		List<TestPojoV2> deserializedPojos = objectMapper.deserialize(jsonPojo, genericListType.getType(), 1);
 		assertEquals(1, deserializedPojos.size());
@@ -112,7 +110,7 @@ public class VersionedJsonObjectMapperTest {
 		assertEquals("defaultBar", deserializedPojos.get(0).getBar());
 	}
 	
-	private final class TestPojoV1ToV2Migration implements AstrixJsonApiMigration {
+	private static final class TestPojoV1ToV2Migration implements AstrixJsonApiMigration {
 		@Override
 		public AstrixJsonMessageMigration<?>[] getMigrations() {
 			return new AstrixJsonMessageMigration<?>[] {

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,6 @@
 		<hystrix.version>1.5.18</hystrix.version>
 		<archaius.version>0.4.1</archaius.version>
 		<jackson2.version>2.11.2</jackson2.version>
-		<guava.version>29.0-jre</guava.version>
 		<junit.version>4.13.1</junit.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<mockito.version>3.8.0</mockito.version>
@@ -265,9 +264,9 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>${guava.version}</version>
+				<groupId>com.google.code.findbugs</groupId>
+				<artifactId>jsr305</artifactId>
+				<version>3.0.2</version>
 			</dependency>
 
             <!-- Java 11 back-comp -->
@@ -281,7 +280,7 @@
 			<dependency>
 				<groupId>org.reflections</groupId>
 				<artifactId>reflections</artifactId>
-				<version>0.9.9</version>
+				<version>0.9.12</version>
 			</dependency>
 			
             <!-- Jackson 2.x -->


### PR DESCRIPTION
Update reflections to 0.9.12. Note that this version misbehaves a bit in that it throws an exception when retrieving results from a scan that did not match anything. This is handled by catching the exception and returning empty in our code. The bug was fixed in April 2020 (https://github.com/ronmamo/reflections/commit/9a1ac08d59311a91f3dad06f0c831eccdc47f1e3) but no new version has been released yet.
Remove remaining usages of Guava in tests.
Add dependency to `jsr305` in `astrix-gs`, for `@GuardedBy` annotation. This annotation is not retained at runtime, therefore the dependency is _optional_. An optional dependency is present at compile time but not at runtime.