### PR TITLE
TP-772: Allow custom `MapConfigSource` in `InMemoryServiceRegistry`

### DIFF
--- a/astrix-context/src/main/java/com/avanza/astrix/beans/registry/InMemoryServiceRegistry.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/registry/InMemoryServiceRegistry.java
@@ -15,6 +15,8 @@
  */
 package com.avanza.astrix.beans.registry;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -43,18 +45,23 @@ import com.avanza.astrix.provider.core.AstrixServiceExport;
 @AstrixServiceExport(AstrixServiceRegistry.class)
 public class InMemoryServiceRegistry implements DynamicConfigSource, AstrixServiceRegistry, MutableConfigSource {
 	
-	private final MapConfigSource configSource = new MapConfigSource();
-	private String id;
-	private String configSourceId;
-	private InMemoryServiceRegistryRepo repo = new InMemoryServiceRegistryRepo();
-	private AstrixServiceRegistry serviceRegistry = new AstrixServiceRegistryImpl(repo);
-	
+	private final MapConfigSource configSource;
+	private final String id;
+	private final String configSourceId;
+	private final InMemoryServiceRegistryRepo repo = new InMemoryServiceRegistryRepo();
+	private final AstrixServiceRegistry serviceRegistry = new AstrixServiceRegistryImpl(repo);
+
 	public InMemoryServiceRegistry() {
+		this(new MapConfigSource());
+	}
+
+	public InMemoryServiceRegistry(MapConfigSource configSource) {
 		this.id = DirectComponent.register(AstrixServiceRegistry.class, this);
+		this.configSource = requireNonNull(configSource);
 		this.configSourceId = GlobalConfigSourceRegistry.register(this);
 		this.configSource.set(AstrixSettings.SERVICE_REGISTRY_URI, getServiceUri());
 	}
-	
+
 	@Override
 	public List<AstrixServiceRegistryEntry> listServices() {
 		return serviceRegistry.listServices();

--- a/astrix-test-support-junit4/src/main/java/com/avanza/astrix/test/AstrixRule.java
+++ b/astrix-test-support-junit4/src/main/java/com/avanza/astrix/test/AstrixRule.java
@@ -16,6 +16,7 @@
 package com.avanza.astrix.test;
 
 import com.avanza.astrix.config.GlobalConfigSourceRegistry;
+import com.avanza.astrix.config.MapConfigSource;
 import com.avanza.astrix.config.Setting;
 import com.avanza.astrix.context.Astrix;
 import com.avanza.astrix.context.AstrixContext;
@@ -71,12 +72,29 @@ public class AstrixRule implements TestRule {
 
 	@SafeVarargs
 	public AstrixRule(Class<? extends TestApi>... testApis) {
-		this.astrixTestContext = new AstrixTestContext(testApis);
+		this(new MapConfigSource(), testApis);
+	}
+
+	@SafeVarargs
+	public AstrixRule(
+			MapConfigSource configSource,
+			Class<? extends TestApi>... testApis
+	) {
+		this.astrixTestContext = new AstrixTestContext(configSource, testApis);
 	}
 
 	@SafeVarargs
 	public AstrixRule(Consumer<? super AstrixRuleContext> contextConfigurer, Class<? extends TestApi>... testApis) {
-		this(testApis);
+		this(new MapConfigSource(), contextConfigurer, testApis);
+	}
+
+	@SafeVarargs
+	public AstrixRule(
+			MapConfigSource configSource,
+			Consumer<? super AstrixRuleContext> contextConfigurer,
+			Class<? extends TestApi>... testApis
+	) {
+		this(configSource, testApis);
 		contextConfigurer.accept(new AstrixRuleContext() {
             @Override
             public <T> void registerProxy(Class<T> service) {

--- a/astrix-test-support-junit5/src/main/java/com/avanza/astrix/test/AstrixExtension.java
+++ b/astrix-test-support-junit5/src/main/java/com/avanza/astrix/test/AstrixExtension.java
@@ -144,21 +144,12 @@ public class AstrixExtension implements ParameterResolver, BeforeAllCallback, Af
     }
 
     public AstrixTestContext getAstrixTestContext(ExtensionContext context) {
-        final MapConfigSource configSource = getMapConfigSource(context);
         return getStore(context).getOrComputeIfAbsent(context.getRequiredTestClass(),
                                                       key -> new AstrixTestContext(
-                                                              configSource,
+                                                              new MapConfigSource(),
                                                               getConfiguration(context).getTestApis()
                                                       ),
                                                       AstrixTestContext.class);
-    }
-
-    private MapConfigSource getMapConfigSource(ExtensionContext context) {
-        return getStore(context).getOrComputeIfAbsent(
-                MapConfigSource.class.getName(),
-                key -> new MapConfigSource(),
-                MapConfigSource.class
-        );
     }
 
     private Configuration getConfiguration(ExtensionContext context) {


### PR DESCRIPTION
* Updates `InMemoryServiceRegistry` so that it may take a user-supplied instance of `MapConfigSource`, instead of always creating a new config source.
* Updates test rule setup classes to allow sending such a custom `MapConfigSource` when setting up tests.
* Reason for allowing a custom `MapConfigSource` is to make it easier for surrounding frameworks to interoperate with Astrix during test setup.