### PR TITLE
TP-722: Add getters for `MapConfigSource` to `AstrixRule`

### DIFF
--- a/astrix-context/src/main/java/com/avanza/astrix/beans/registry/InMemoryServiceRegistry.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/registry/InMemoryServiceRegistry.java
@@ -90,7 +90,11 @@ public class InMemoryServiceRegistry implements DynamicConfigSource, AstrixServi
 	public String getConfigSourceId() {
 		return configSourceId;
 	}
-	
+
+	public MapConfigSource getConfigSource() {
+		return configSource;
+	}
+
 	public void clear() {
 		this.repo.clear();
 	}

--- a/astrix-test-support-common/src/main/java/com/avanza/astrix/test/AstrixTestContext.java
+++ b/astrix-test-support-common/src/main/java/com/avanza/astrix/test/AstrixTestContext.java
@@ -70,6 +70,10 @@ public class AstrixTestContext implements AstrixContext {
 		return serviceRegistry.getConfigSourceId();
 	}
 
+	public MapConfigSource getConfigSource() {
+		return serviceRegistry.getConfigSource();
+	}
+
 	/**
 	 * @return the serviceUri for the associated service-registry.
 	 */

--- a/astrix-test-support-junit4/src/main/java/com/avanza/astrix/test/AstrixRule.java
+++ b/astrix-test-support-junit4/src/main/java/com/avanza/astrix/test/AstrixRule.java
@@ -143,6 +143,10 @@ public class AstrixRule implements TestRule {
 		return astrixTestContext.getConfigSourceId();
 	}
 
+	public MapConfigSource getConfigSource() {
+		return astrixTestContext.getConfigSource();
+	}
+
 	/**
 	 * @return the serviceUri for the associated service-registry.
 	 */


### PR DESCRIPTION
* Adds getter for `MapConfigSource` in `AstrixRule`
* This is a continuation of the work to make it easier for surrounding frameworks to interoperate with Astrix during test setup.