### PR TITLE
TP-780: Only specify astrix libs in astrix-bom

### DIFF
--- a/astrix-bom/pom.xml
+++ b/astrix-bom/pom.xml
@@ -1,11 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-        <relativePath />
-    </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/astrix-bom/pom.xml
+++ b/astrix-bom/pom.xml
@@ -1,16 +1,61 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>com.avanza.astrix</groupId>
-        <artifactId>astrix-parent</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>9</version>
+        <relativePath />
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
+    <groupId>com.avanza.astrix</groupId>
     <artifactId>astrix-bom</artifactId>
+    <version>1.0.4-SNAPSHOT</version>
     <name>${project.artifactId}</name>
+
+    <description>Astrix (Bill of Materials)</description>
+    <url>https://github.com/AvanzaBank/astrix</url>
+
+    <organization>
+        <name>Avanza Bank AB</name>
+        <url>https://www.avanza.se/</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+    <inceptionYear>2014</inceptionYear>
+
+    <scm>
+        <connection>scm:git:git@github.com:AvanzaBank/astrix.git</connection>
+        <developerConnection>scm:git:git@github.com:AvanzaBank/astrix.git</developerConnection>
+        <url>git@github.com:AvanzaBank/astrix.git</url>
+    </scm>
+
+    <developers>
+        <developer>
+            <name>Elias Lindholm</name>
+            <email>elias.lindholm@avanza.se</email>
+            <organization>Avanza</organization>
+            <organizationUrl>https://github.com/AvanzaBank</organizationUrl>
+        </developer>
+    </developers>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -569,6 +569,8 @@
 					<includes>
 						<include>com.avanza.*</include>
 					</includes>
+					<groupId>com.avanza.*</groupId>
+					<artifactId>*</artifactId>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
* Updates `astrix-bom` so that the versions provided by it only includes astrix components.
* Specifically, with this commit, importing `astrix-bom` in another library does not set the versions that are speciied in this project's parentpom.
* The intention with this commit is, for example, to not specify versions of junit or gigaspaces when importing `astrix-bom`.

Example of the problem before this commit:
```
~/projects/astrix/astrix-bom$ mvn help:effective-pom | fgrep -B 1 -A 3 org.junit  | head -n 5
      <dependency>
        <groupId>org.junit.jupiter</groupId>
        <artifactId>junit-jupiter</artifactId>
        <version>5.7.2</version>
      </dependency>
```

With this commit:
```
~/projects/astrix/astrix-bom$ mvn help:effective-pom | fgrep org.junit
(no output)
```