### PR TITLE
TP-780: Add `maven-enforcer-plugin` for `astrix-bom`

### DIFF
--- a/astrix-bom/pom.xml
+++ b/astrix-bom/pom.xml
@@ -131,4 +131,18 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
* Prevents the following build errors as seen in jenkins build:
```
$ mvn -B -Prelease enforcer:enforce
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0:enforce (default-cli) on project astrix-bom: No rules are configured. Use the skip flag if you want to disable execution. -> [Help 1]
```

Follow-up to #112 