### PR TITLE
Map RxJava Completable asynchronous return type to synchronous void return type

### DIFF
--- a/astrix-integration-tests/src/main/java/com/avanza/astrix/integration/tests/domain/api/LunchServiceAsync.java
+++ b/astrix-integration-tests/src/main/java/com/avanza/astrix/integration/tests/domain/api/LunchServiceAsync.java
@@ -19,7 +19,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import com.avanza.astrix.core.AstrixRouting;
-import com.gigaspaces.async.AsyncFuture;
+
+import rx.Completable;
 
 public interface LunchServiceAsync {
 
@@ -29,5 +30,5 @@ public interface LunchServiceAsync {
 	
 	CompletableFuture<LunchRestaurant> waitForLunchRestaurant(@AstrixRouting String name, int duration, TimeUnit unit);
 	
-	AsyncFuture<Void> addLunchRestaurant(LunchRestaurant restaurant);
+	Completable addLunchRestaurant(LunchRestaurant restaurant);
 }

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/AsyncRemoteServiceTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/AsyncRemoteServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openspaces.core.GigaSpace;
+
 import com.avanza.astrix.beans.core.AstrixSettings;
 import com.avanza.astrix.beans.registry.InMemoryServiceRegistry;
 import com.avanza.astrix.config.DynamicConfig;
@@ -40,6 +41,8 @@ import com.avanza.astrix.integration.tests.domain.api.LunchServiceAsync;
 import com.avanza.astrix.test.util.AutoCloseableRule;
 import com.avanza.gs.test.PuConfigurers;
 import com.avanza.gs.test.RunningPu;
+
+import rx.Completable;
 
 /**
  * 
@@ -86,7 +89,7 @@ public class AsyncRemoteServiceTest {
 		this.lunchServiceAsync = astrix.waitForBean(LunchServiceAsync.class, 10000);
 		this.lunchService = astrix.waitForBean(LunchService.class, 10000);
 	}
-	
+
 	/* NOTE: Since Astrix converts between Future/Observable internally its easy
 	 * to run into a state where asynchronous calls becomes effectively synchronous.
 	 * 
@@ -113,7 +116,7 @@ public class AsyncRemoteServiceTest {
 		
 		// By adding the LunchRestaurant asynchronously and not invoke Future.get we ensure that the underlying 
 		// service invocation is really started
-		Future<Void> addLunchRestaurant = lunchServiceAsync.addLunchRestaurant(lunchRestaurant().withName("Martins Green Room").build());
+		Completable addLunchRestaurant = lunchServiceAsync.addLunchRestaurant(lunchRestaurant().withName("Martins Green Room").build());
 		
 		assertNotNull(lunchRestaurant.get());
 	}


### PR DESCRIPTION
`Completable` is not a parameterized type, but it should map to `void` since it emits no value.

This fixes errors such as this:
```
Caused by: java.lang.ClassCastException: Cannot cast java.lang.Class to java.lang.reflect.ParameterizedType
	at java.lang.Class.cast(Class.java:3605) ~[?:?]
	at com.avanza.astrix.remoting.client.RemotingProxy.getReturnType(RemotingProxy.java:179) ~[astrix-remoting-1.0.6.jar!/:1.0.6]
	at com.avanza.astrix.remoting.client.RemotingProxy.<init>(RemotingProxy.java:111) ~[astrix-remoting-1.0.6.jar!/:1.0.6]
	at com.avanza.astrix.remoting.client.RemotingProxy.create(RemotingProxy.java:85) ~[astrix-remoting-1.0.6.jar!/:1.0.6]
	at com.avanza.astrix.gs.remoting.GsRemotingComponent.bind(GsRemotingComponent.java:102) ~[astrix-gs-1.0.6.jar!/:1.0.6]
	at com.avanza.astrix.beans.service.ServiceBeanInstance$BeanState.bindTo(ServiceBeanInstance.java:306) ~[astrix-context-1.0.6.jar!/:1.0.6]
	at com.avanza.astrix.beans.service.ServiceBeanInstance.bind(ServiceBeanInstance.java:211) ~[astrix-context-1.0.6.jar!/:1.0.6]
	at com.avanza.astrix.beans.service.ServiceBeanInstance.bind(ServiceBeanInstance.java:156) ~[astrix-context-1.0.6.jar!/:1.0.6]
	at com.avanza.astrix.beans.service.ServiceLeaseManager$ServiceBindThread.bind(ServiceLeaseManager.java:103) ~[astrix-context-1.0.6.jar!/:1.0.6]
	at com.avanza.astrix.beans.service.ServiceLeaseManager$ServiceBindThread.run(ServiceLeaseManager.java:88) ~[astrix-context-1.0.6.jar!/:1.0.6]
```

Support for `Completable` return type was introduced in https://github.com/AvanzaBank/astrix/pull/114