### PR TITLE
TP-568: Rebind service beans when PU has restarted

### DIFF
--- a/astrix-context/src/main/java/com/avanza/astrix/beans/service/ServiceBeanInstance.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/service/ServiceBeanInstance.java
@@ -118,6 +118,10 @@ public class ServiceBeanInstance<T> implements StatefulAstrixBean, InvocationHan
 				return;
 			}
 			if (serviceHasChanged(serviceDiscoveryResult.getResult())) {
+				if (isBound() && currentProperties != null) {
+					log.info("Service properties for bean={} astrixBeanId={} have changed, will rebind service bean.", getBeanKey(), id);
+					destroy();
+				}
 				bind(serviceDiscoveryResult.getResult());
 			} else {
 				log.debug("Service properties have not changed. No need to bind bean=" + getBeanKey());
@@ -216,6 +220,7 @@ public class ServiceBeanInstance<T> implements StatefulAstrixBean, InvocationHan
 		beanStateLock.lock();
 		try {
 			this.currentState.releaseInstance();
+			this.currentState = new Unbound(ServiceUnavailableException.class, "Service is unavailable");
 		} finally {
 			beanStateLock.unlock();
 		}

--- a/astrix-context/src/main/java/com/avanza/astrix/beans/service/ServiceBeanInstance.java
+++ b/astrix-context/src/main/java/com/avanza/astrix/beans/service/ServiceBeanInstance.java
@@ -119,8 +119,8 @@ public class ServiceBeanInstance<T> implements StatefulAstrixBean, InvocationHan
 			}
 			if (serviceHasChanged(serviceDiscoveryResult.getResult())) {
 				if (isBound() && currentProperties != null) {
-					log.info("Service properties for bean={} astrixBeanId={} have changed, will rebind service bean.", getBeanKey(), id);
-					destroy();
+					log.info("Service properties for bean={} astrixBeanId={} have changed, will unbind current service bean and rebind new bean.", getBeanKey(), id);
+					unbind();
 				}
 				bind(serviceDiscoveryResult.getResult());
 			} else {
@@ -220,10 +220,14 @@ public class ServiceBeanInstance<T> implements StatefulAstrixBean, InvocationHan
 		beanStateLock.lock();
 		try {
 			this.currentState.releaseInstance();
-			this.currentState = new Unbound(ServiceUnavailableException.class, "Service is unavailable");
 		} finally {
 			beanStateLock.unlock();
 		}
+	}
+
+	private void unbind() {
+		this.currentState.releaseInstance();
+		this.currentState = new Unbound(ServiceUnavailableException.class, "Service is unavailable");
 	}
 
 	private void notifyBound() {

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/RestartSpaceTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/RestartSpaceTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.integration.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openspaces.core.cluster.ClusterInfo;
+import org.openspaces.core.properties.BeanLevelProperties;
+import org.openspaces.pu.container.ProcessingUnitContainer;
+import org.openspaces.pu.container.integrated.IntegratedProcessingUnitContainerProvider;
+
+import com.avanza.astrix.beans.core.AstrixSettings;
+import com.avanza.astrix.config.DynamicConfig;
+import com.avanza.astrix.config.GlobalConfigSourceRegistry;
+import com.avanza.astrix.config.MapConfigSource;
+import com.avanza.astrix.context.AstrixConfigurer;
+import com.avanza.astrix.context.AstrixContext;
+import com.avanza.astrix.integration.tests.domain.api.LunchRestaurant;
+import com.avanza.astrix.integration.tests.domain.api.LunchService;
+import com.avanza.gs.test.JVMGlobalLus;
+import com.avanza.gs.test.PuConfigurers;
+import com.avanza.gs.test.RunningPu;
+
+public class RestartSpaceTest {
+	private final String lookupGroupName = JVMGlobalLus.getLookupGroupName();
+	private final MapConfigSource configSource = new MapConfigSource() {{
+		set(AstrixSettings.SERVICE_REGISTRY_URI, "gs-remoting:jini://*/*/service-registry-space?groups=" + lookupGroupName);
+		set(AstrixSettings.BEAN_BIND_ATTEMPT_INTERVAL, 250);
+		set(AstrixSettings.SERVICE_LEASE_RENEW_INTERVAL, 100);
+		set(AstrixSettings.SERVICE_REGISTRY_EXPORT_INTERVAL, 150);
+	}};
+	private final String configSourceId = GlobalConfigSourceRegistry.register(configSource);
+	private final DynamicConfig dynamicConfig = new DynamicConfig(configSource);
+	@Rule
+	public final RunningPu serviceRegistryPu = PuConfigurers.partitionedPu("classpath:/META-INF/spring/service-registry-pu.xml")
+			.lookupGroup(lookupGroupName)
+			.startAsync(false)
+			.configure();
+	private AstrixContext astrix;
+	private ProcessingUnitContainer pu;
+
+	@After
+	public void afterEachTest() throws Exception {
+		if (astrix != null) {
+			astrix.close();
+		}
+		if (pu != null) {
+			pu.close();
+		}
+	}
+
+	private ProcessingUnitContainer startPuContainer() throws IOException {
+		Properties contextProperties = new Properties();
+		contextProperties.put("spaceName", this.getClass().getName());
+		contextProperties.put("configSourceId", configSourceId);
+		contextProperties.put("gs.space.url.arg.groups", this.lookupGroupName);
+		BeanLevelProperties beanLevelProperties = new BeanLevelProperties();
+		beanLevelProperties.setContextProperties(contextProperties);
+
+		// Cannot use "PuConfigurers.partitionedPu" for this space since it
+		// gives a unique spacename for each start, and we want to restart with
+		// the same spacename in these tests.
+		IntegratedProcessingUnitContainerProvider provider = new IntegratedProcessingUnitContainerProvider();
+		provider.setClusterInfo(new ClusterInfo("partitioned", 1, 0, 1, 0));
+		provider.addConfigLocation("classpath:/META-INF/spring/lunch-pu.xml");
+		provider.setBeanLevelProperties(beanLevelProperties);
+		return provider.createContainer();
+	}
+
+	@Test
+	public void shouldCallAstrixServiceWithoutExceptionsWhenPuHasRestarted() throws Exception {
+		// Arrange
+		pu = startPuContainer();
+		astrix = new AstrixConfigurer().setConfig(dynamicConfig).configure();
+		LunchService lunchService = astrix.waitForBean(LunchService.class, 5000);
+		List<LunchRestaurant> response1 = lunchService.getLunchRestaurants("request");
+
+		// Act
+		pu.close();
+		pu = startPuContainer();
+		// Wait for service renewal to execute
+		Thread.sleep(1_000);
+
+		// Assert
+		List<LunchRestaurant> response2 = lunchService.getLunchRestaurants("request");
+		assertEquals(response1, response2);
+	}
+}

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/ServiceRegistryPuIntegrationTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/ServiceRegistryPuIntegrationTest.java
@@ -17,11 +17,15 @@ package com.avanza.astrix.integration.tests;
 
 import static org.junit.Assert.assertEquals;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import com.avanza.astrix.beans.core.AstrixBeanKey;
 import com.avanza.astrix.beans.core.AstrixSettings;
 import com.avanza.astrix.beans.registry.AstrixServiceRegistry;
@@ -32,6 +36,7 @@ import com.avanza.astrix.config.DynamicConfig;
 import com.avanza.astrix.config.MapConfigSource;
 import com.avanza.astrix.context.AstrixConfigurer;
 import com.avanza.astrix.context.AstrixContext;
+import com.avanza.astrix.gs.GsBinder;
 import com.avanza.astrix.provider.component.AstrixServiceComponentNames;
 import com.avanza.astrix.test.util.AutoCloseableRule;
 import com.avanza.gs.test.PuConfigurers;
@@ -108,5 +113,34 @@ public class ServiceRegistryPuIntegrationTest {
 	
 	interface AnotherService {
 	}
-	
+
+	@Test
+	public void serviceRegistrationRetainsHighestValueOfPuStartTime() {
+		// Arrange
+		AstrixServiceRegistry serviceRegistry = clientContext.getBean(AstrixServiceRegistry.class);
+		ServiceRegistryClient serviceRegistryClient = clientContext.getBean(ServiceRegistryClient.class);
+		ServiceRegistryExporterClient exporterClient = new ServiceRegistryExporterClient(serviceRegistry, "default", "app-instance-1");
+		Instant t0 = Instant.parse("2021-01-01T12:00:00.000Z");
+		Instant t1 = t0.plus(5, ChronoUnit.MINUTES);
+		String t0AsString = String.valueOf(t0.toEpochMilli());
+		String t1AsString = String.valueOf(t1.toEpochMilli());
+		ServiceProperties props0 = new ServiceProperties(Map.of(GsBinder.START_TIME, t0AsString));
+		ServiceProperties props1 = new ServiceProperties(Map.of(GsBinder.START_TIME, t1AsString));
+		long lease = 5000;
+
+		// Act
+		exporterClient.register(SomeService.class, props0, lease);
+		exporterClient.register(SomeService.class, props1, lease);
+		exporterClient.register(AnotherService.class, props1, lease);
+		exporterClient.register(AnotherService.class, props0, lease);
+
+		// Assert
+		ServiceProperties foundProps1 = serviceRegistryClient.lookup(AstrixBeanKey.create(SomeService.class));
+		ServiceProperties foundProps2 = serviceRegistryClient.lookup(AstrixBeanKey.create(AnotherService.class));
+		// We want to make sure that both registrations have stored the time of
+		// "t1" in its registration (the max value of all "startTime").
+		// Specifically, they should *not* have "t0".
+		assertEquals(t1AsString, foundProps1.getProperty(GsBinder.START_TIME));
+		assertEquals(t1AsString, foundProps2.getProperty(GsBinder.START_TIME));
+	}
 }


### PR DESCRIPTION
* Makes Astrix clients rebind their service beans whenever any of the PUs in the space have restarted.
* Reason for rebinding is to make sure that clients have up-to-date connection details to which hosts that the space resides on, in case any of the server-side PUs have been relocated or restarted.
* However, GS will detect if any instances have moved automatically, but only after an initial failed connection to any such outdated instances - which might result in timeouts. With this commit, the intention is that such timeouts will be less likely.
* Before this change, if any of the PU instances had been relocated, all clients would fail their connections to the previous relocated instance at least once.
* In particular, this commit intends to resolve the case where
	* An instance of a PU has been relocated to a new server
	* The old server is unavailable, and network requests to it will time-out instead of being rejected
	* The astrix service is called seldomly (for example, only at a certain time during the day)
	* Such a case would previously get timeout on the first (next) call after the PU had been restarted. For example, the next day when the calling app needs the service again.
	* With this commit, the calling apps will reconnect some time after the PU has been relocated.

Example testcase that was used to verify this change:
* 0min: An app calls an astrix service on a PU using `@AstrixBroadcast`
* 1min: One instance of the PU partitions is restarted
* 3min: The calling app makes the same broadcast call again

Results before this proposed change:
* 0min: The call succeeds without exception
* 3min: Calling app logs `WARN: Async execution failed: java.rmi.ConnectException: Broken pipe`
* 3min: The call succeeds without exception (the code making the astrix call does not see the exception logged above)
* The calling app has therefore tried to make at least one network connection to an old PU instance

Results with this commit:
* 0min: The call succeeds without exception
* 1min 15s: The calling app logs `Service properties for bean=... have changed, will rebind`
* 3min: The call succeeds without exception
* The calling app has not logged any WARN logs.
* The calling app has not tried to connect to the old PU instance