### PR TITLE
TP-1010: Bugfix: Allow `DynamicConfig` from parent spring ctx

### DIFF
--- a/astrix-spring/src/main/java/com/avanza/astrix/spring/AstrixFrameworkBean.java
+++ b/astrix-spring/src/main/java/com/avanza/astrix/spring/AstrixFrameworkBean.java
@@ -17,7 +17,6 @@ package com.avanza.astrix.spring;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +24,8 @@ import java.util.Map;
 import javax.annotation.PreDestroy;
 
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
@@ -36,9 +37,8 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.ContextStoppedEvent;
 import org.springframework.core.Ordered;
 
-import com.avanza.astrix.beans.core.AstrixBeanSettings.BeanSetting;
 import com.avanza.astrix.beans.core.AstrixBeanKey;
-import com.avanza.astrix.beans.core.AstrixSettings;
+import com.avanza.astrix.beans.core.AstrixBeanSettings.BeanSetting;
 import com.avanza.astrix.config.DynamicConfig;
 import com.avanza.astrix.config.Setting;
 import com.avanza.astrix.context.Astrix;
@@ -197,14 +197,13 @@ public class AstrixFrameworkBean implements BeanFactoryPostProcessor, Applicatio
 	}
 	
 	private DynamicConfig getDynamicConfig(ApplicationContext applicationContext) {
-		Collection<DynamicConfig> dynamicConfigs = applicationContext.getBeansOfType(DynamicConfig.class).values();
-		if (dynamicConfigs.isEmpty()) {
+		try {
+			return applicationContext.getBean(DynamicConfig.class);
+		} catch (NoUniqueBeanDefinitionException e) {
+			throw new IllegalArgumentException("Multiple DynamicConfig instances found in ApplicationContext: " + e);
+		} catch (NoSuchBeanDefinitionException ignored) {
 			return null;
 		}
-		if (dynamicConfigs.size() == 1) {
-			return dynamicConfigs.iterator().next();
-		}
-		throw new IllegalArgumentException("Multiple DynamicConfig instances found in ApplicationContext");
 	}
 	
 	private AstrixApplicationContext createAstrixContext(DynamicConfig optionalConfig) {

--- a/astrix-spring/src/test/java/com/avanza/astrix/context/AstrixContextTestUtil.java
+++ b/astrix-spring/src/test/java/com/avanza/astrix/context/AstrixContextTestUtil.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.context;
+
+// Allows using methods and classes that are otherwise package-private in tests.
+public class AstrixContextTestUtil {
+	public static <T> T getInternalInstance(AstrixContext ctx, Class<T> type) {
+		return ((AstrixContextImpl) ctx).getInstance(type);
+	}
+}

--- a/astrix-spring/src/test/java/com/avanza/astrix/spring/AstrixFrameworkBeanDynamicConfigTest.java
+++ b/astrix-spring/src/test/java/com/avanza/astrix/spring/AstrixFrameworkBeanDynamicConfigTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.spring;
+
+import static com.avanza.astrix.context.AstrixContextTestUtil.getInternalInstance;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.avanza.astrix.beans.config.AstrixConfig;
+import com.avanza.astrix.config.DynamicConfig;
+import com.avanza.astrix.config.MapConfigSource;
+import com.avanza.astrix.context.AstrixContext;
+
+public class AstrixFrameworkBeanDynamicConfigTest {
+
+	@Configuration
+	public static class ParentSpringConfiguration {
+		@Bean
+		public DynamicConfig dynamicConfig() {
+			return DynamicConfig.create(MapConfigSource.of("key", "parent"));
+		}
+	}
+
+	@Configuration
+	public static class ExampleAppConfiguration {
+		@Bean
+		public AstrixFrameworkBean astrixFrameworkBean() {
+			return new AstrixFrameworkBean();
+		}
+	}
+
+	private final DynamicConfig customDynamicConfig = DynamicConfig.create(MapConfigSource.of("key", "custom"));
+
+	private static DynamicConfig getDynamicConfig(AstrixContext astrixContext) {
+		return getInternalInstance(astrixContext, AstrixConfig.class).getConfig();
+	}
+
+	@Test
+	public void shouldGetDynamicConfigFromCustomSpringConfig() {
+		// Arrange
+		try (var c = new AnnotationConfigApplicationContext()) {
+			c.registerBean(DynamicConfig.class, () -> customDynamicConfig);
+			c.register(ExampleAppConfiguration.class);
+			c.refresh();
+
+			// Act
+			String actual = getDynamicConfig(c.getBean(AstrixContext.class))
+					.getStringProperty("key", "").get();
+
+			// Assert
+			assertEquals("custom", actual);
+		}
+	}
+
+	@Test
+	public void shouldGetDynamicConfigFromCustomSpringConfigThatAlsoHasParent() {
+		// Arrange
+		try (var parent = new AnnotationConfigApplicationContext(ParentSpringConfiguration.class)) {
+			try (var c = new AnnotationConfigApplicationContext()) {
+				c.setParent(parent);
+				c.registerBean(DynamicConfig.class, () -> customDynamicConfig);
+				c.register(ExampleAppConfiguration.class);
+				c.refresh();
+
+				// Act
+				String actual = getDynamicConfig(c.getBean(AstrixContext.class))
+						.getStringProperty("key", "").get();
+
+				// Assert
+				assertEquals("custom", actual);
+			}
+		}
+	}
+
+	@Test
+	public void shouldGetDynamicConfigEvenIfSpringConfigDoesNotDefineIt() {
+		// Arrange
+		try (var c = new AnnotationConfigApplicationContext(ExampleAppConfiguration.class)) {
+
+			// Act
+			String actual = getDynamicConfig(c.getBean(AstrixContext.class))
+					.getStringProperty("key", "").get();
+
+			// Assert
+			assertEquals("", actual);
+		}
+	}
+
+	@Test
+	public void shouldGetDynamicConfigFromParentContextIfSpringConfigDoesNotDefineIt() {
+		// Arrange
+		try (var parent = new AnnotationConfigApplicationContext(ParentSpringConfiguration.class)) {
+			try (var c = new AnnotationConfigApplicationContext()) {
+				c.setParent(parent);
+				c.register(ExampleAppConfiguration.class);
+				c.refresh();
+
+				// Act
+				String actual = getDynamicConfig(c.getBean(AstrixContext.class))
+						.getStringProperty("key", "").get();
+
+				// Assert
+				assertEquals("parent", actual);
+			}
+		}
+	}
+
+	@Test
+	public void shouldNotAllowMultipleDynamicConfigSpringBeans() {
+		// Arrange
+		try (var c = new AnnotationConfigApplicationContext()) {
+			c.registerBean("config1", DynamicConfig.class, () -> customDynamicConfig);
+			c.registerBean("config2", DynamicConfig.class, () -> customDynamicConfig);
+			c.register(ExampleAppConfiguration.class);
+
+			// Act
+			var expected = assertThrows(IllegalArgumentException.class, c::refresh);
+
+			// Assert
+			assertThat(expected.getMessage(), containsString("Multiple DynamicConfig instances found in ApplicationContext"));
+		}
+	}
+}


### PR DESCRIPTION
* Allows astrix to find an instance of `DynamicConfig` not only from the application spring context, but also from its parent context(s).
* Reason for updating is to make it more similar to how bean resolution in spring usually works: if a bean is provided by a parent context, it is usually available to the app in the same way as if it had been present in the application's own context.
* Specifically, this will allow unit tests that define `DynamicConfig` in parent contexts, and specific contexts that reuse it.