### PR TITLE
TP-687: WIP on using unicast when running tests with gs-test

### DIFF
--- a/astrix-integration-tests/pom.xml
+++ b/astrix-integration-tests/pom.xml
@@ -45,7 +45,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.avanza.gs</groupId>
-			<artifactId>gs-test</artifactId>
+			<artifactId>gs-test-junit4</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/AstrixIntegrationTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/AstrixIntegrationTest.java
@@ -87,8 +87,8 @@ public class AstrixIntegrationTest {
 															.startAsync(true)
 															.configure();
 	
-	private static MapConfigSource config = new MapConfigSource() {{
-		set(AstrixSettings.SERVICE_REGISTRY_URI, AstrixServiceComponentNames.GS_REMOTING + ":jini://*/*/service-registry-space?groups=" + serviceRegistrypu.getLookupGroupName());
+	private static final MapConfigSource config = new MapConfigSource() {{
+		set(AstrixSettings.SERVICE_REGISTRY_URI, AstrixServiceComponentNames.GS_REMOTING + ":jini://*/*/service-registry-space?locators=" + serviceRegistrypu.getLookupLocator());
 		set(AstrixSettings.SERVICE_REGISTRY_EXPORT_RETRY_INTERVAL, 250);
 		set(AstrixSettings.BEAN_BIND_ATTEMPT_INTERVAL, 250);
 	}};

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/GsRemotingTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/GsRemotingTest.java
@@ -45,12 +45,12 @@ import com.avanza.astrix.provider.core.AstrixServiceExport;
 import com.avanza.astrix.provider.core.Service;
 import com.avanza.astrix.spring.AstrixFrameworkBean;
 import com.avanza.astrix.test.util.AutoCloseableRule;
-import com.avanza.gs.test.JVMGlobalLus;
+import com.avanza.gs.test.JVMGlobalGigaSpacesManager;
 import com.j_spaces.core.IJSpace;
 
 public class GsRemotingTest {
 	
-	private InMemoryServiceRegistry serviceRegistry = new InMemoryServiceRegistry();
+	private final InMemoryServiceRegistry serviceRegistry = new InMemoryServiceRegistry();
 	
 	@Rule 
 	public AutoCloseableRule autoClosables = new AutoCloseableRule();
@@ -59,7 +59,7 @@ public class GsRemotingTest {
 	public void routedServiceInvocationThrowServiceUnavailableWhenProxyIsContextIsClosed() throws Exception {
 		AnnotationConfigApplicationContext pingServer = autoClosables.add(new AnnotationConfigApplicationContext());
 		pingServer.register(PingAppConfig.class);
-		pingServer.getEnvironment().getPropertySources().addFirst(new MapPropertySource("props", new HashMap<String, Object>() {{
+		pingServer.getEnvironment().getPropertySources().addFirst(new MapPropertySource("props", new HashMap<>() {{
 			put("serviceRegistryUri", serviceRegistry.getServiceUri());
 		}}));
 		pingServer.refresh();
@@ -82,7 +82,7 @@ public class GsRemotingTest {
 	public void broadcastedServiceInvocationThrowServiceUnavailableWhenProxyIsContextIsClosed() throws Exception {
 		AnnotationConfigApplicationContext pingServer = autoClosables.add(new AnnotationConfigApplicationContext());
 		pingServer.register(PingAppConfig.class);
-		pingServer.getEnvironment().getPropertySources().addFirst(new MapPropertySource("props", new HashMap<String, Object>() {{
+		pingServer.getEnvironment().getPropertySources().addFirst(new MapPropertySource("props", new HashMap<>() {{
 			put("serviceRegistryUri", serviceRegistry.getServiceUri());
 		}}));
 		pingServer.refresh();
@@ -126,11 +126,9 @@ public class GsRemotingTest {
 		}
 	}
 
-
 	@AstrixApplication(exportsRemoteServicesFor = PingApi.class, defaultServiceComponent = AstrixServiceComponentNames.GS_REMOTING)
 	public static class PingAppConfig {
-		
-		
+
 		@Bean
 		public AstrixFrameworkBean astrix(Environment env) {
 			AstrixFrameworkBean astrix = new AstrixFrameworkBean();
@@ -143,14 +141,16 @@ public class GsRemotingTest {
 		public Ping ping() {
 			return new PingImpl();
 		}
+
 		@Bean
 		public GigaSpace gs(IJSpace space) {
 			return new GigaSpaceConfigurer(space).create();
 		}
+
 		@Bean
 		public EmbeddedSpaceFactoryBean spaceFactoryBean() {
 			EmbeddedSpaceFactoryBean spaceFactory = new EmbeddedSpaceFactoryBean(UniqueSpaceNameSeed.getSpaceName());
-			spaceFactory.setLookupGroups(JVMGlobalLus.getLookupGroupName());
+			spaceFactory.setLookupLocators(JVMGlobalGigaSpacesManager.getLookupLocator());
 			return spaceFactory;
 		}
 	}

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/RestartSpaceTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/RestartSpaceTest.java
@@ -48,16 +48,16 @@ import com.avanza.astrix.integration.tests.domain.api.LunchRestaurant;
 import com.avanza.astrix.integration.tests.domain.api.LunchService;
 import com.avanza.astrix.integration.tests.domain.api.LunchServiceAsync;
 import com.avanza.astrix.modules.ObjectCache;
-import com.avanza.gs.test.JVMGlobalLus;
+import com.avanza.gs.test.JVMGlobalGigaSpacesManager;
 import com.avanza.gs.test.PuConfigurers;
 import com.avanza.gs.test.RunningPu;
 
 public class RestartSpaceTest {
-	private final String lookupGroupName = JVMGlobalLus.getLookupGroupName();
+	private final String lookupLocator = JVMGlobalGigaSpacesManager.getLookupLocator();
 	private final String spaceName = this.getClass().getName();
-	private final String puSpaceUrl = "jini://*/*/" + spaceName + "?groups=" + lookupGroupName;
+	private final String puSpaceUrl = "jini://*/*/" + spaceName + "?locators=" + lookupLocator;
 	private final MapConfigSource configSource = new MapConfigSource() {{
-		set(AstrixSettings.SERVICE_REGISTRY_URI, "gs-remoting:jini://*/*/service-registry-space?groups=" + lookupGroupName);
+		set(AstrixSettings.SERVICE_REGISTRY_URI, "gs-remoting:jini://*/*/service-registry-space?locators=" + lookupLocator);
 		set(AstrixSettings.BEAN_BIND_ATTEMPT_INTERVAL, 250);
 		set(AstrixSettings.SERVICE_LEASE_RENEW_INTERVAL, 100);
 		set(AstrixSettings.SERVICE_REGISTRY_EXPORT_INTERVAL, 150);
@@ -66,7 +66,7 @@ public class RestartSpaceTest {
 	private final DynamicConfig dynamicConfig = new DynamicConfig(configSource);
 	@Rule
 	public final RunningPu serviceRegistryPu = PuConfigurers.partitionedPu("classpath:/META-INF/spring/service-registry-pu.xml")
-			.lookupGroup(lookupGroupName)
+			.lookupLocator(lookupLocator)
 			.startAsync(false)
 			.configure();
 	private AstrixContext astrix;
@@ -110,7 +110,7 @@ public class RestartSpaceTest {
 		Properties contextProperties = new Properties();
 		contextProperties.put("spaceName", spaceName);
 		contextProperties.put("configSourceId", configSourceId);
-		contextProperties.put("gs.space.url.arg.groups", this.lookupGroupName);
+		contextProperties.put("gs.space.url.arg.locators", this.lookupLocator);
 		BeanLevelProperties beanLevelProperties = new BeanLevelProperties();
 		beanLevelProperties.setContextProperties(contextProperties);
 

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/ServiceRegistryPuIntegrationTest.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/ServiceRegistryPuIntegrationTest.java
@@ -56,8 +56,8 @@ public class ServiceRegistryPuIntegrationTest {
 															.startAsync(false)
 															.configure();
 	
-	private MapConfigSource clientConfig = new MapConfigSource() {{
-		set(AstrixSettings.SERVICE_REGISTRY_URI, AstrixServiceComponentNames.GS_REMOTING + ":jini://*/*/service-registry-space?groups=" + serviceRegistrypu.getLookupGroupName());
+	private final MapConfigSource clientConfig = new MapConfigSource() {{
+		set(AstrixSettings.SERVICE_REGISTRY_URI, AstrixServiceComponentNames.GS_REMOTING + ":jini://*/*/service-registry-space?locators=" + serviceRegistrypu.getLookupLocator());
 	}};
 	
 	private AstrixContext clientContext;

--- a/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/TracingTests.java
+++ b/astrix-integration-tests/src/test/java/com/avanza/astrix/integration/tests/TracingTests.java
@@ -48,8 +48,8 @@ public class TracingTests {
             .startAsync(true)
             .configure();
 
-    private static MapConfigSource config = new MapConfigSource() {{
-        set(AstrixSettings.SERVICE_REGISTRY_URI, AstrixServiceComponentNames.GS_REMOTING + ":jini://*/*/service-registry-space?groups=" + serviceRegistrypu.getLookupGroupName());
+    private static final MapConfigSource config = new MapConfigSource() {{
+        set(AstrixSettings.SERVICE_REGISTRY_URI, AstrixServiceComponentNames.GS_REMOTING + ":jini://*/*/service-registry-space?locators=" + serviceRegistrypu.getLookupLocator());
         set(AstrixSettings.SERVICE_REGISTRY_EXPORT_RETRY_INTERVAL, 250);
         set(AstrixSettings.BEAN_BIND_ATTEMPT_INTERVAL, 250);
     }};

--- a/doc-snippets/pom.xml
+++ b/doc-snippets/pom.xml
@@ -31,7 +31,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.avanza.gs</groupId>
-			<artifactId>gs-test</artifactId>
+			<artifactId>gs-test-junit4</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/examples/example-application-runners/pom.xml
+++ b/examples/example-application-runners/pom.xml
@@ -19,7 +19,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.avanza.gs</groupId>
-			<artifactId>gs-test</artifactId>
+			<artifactId>gs-test-junit4</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>${astrix.groupId}</groupId>

--- a/examples/lunch-grader-parent/lunch-grader-pu/pom.xml
+++ b/examples/lunch-grader-parent/lunch-grader-pu/pom.xml
@@ -50,7 +50,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.avanza.gs</groupId>
-			<artifactId>gs-test</artifactId>
+			<artifactId>gs-test-junit4</artifactId>
 			<scope>test</scope>
 		</dependency>
 		

--- a/examples/lunch-parent/lunch-pu/pom.xml
+++ b/examples/lunch-parent/lunch-pu/pom.xml
@@ -45,7 +45,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.avanza.gs</groupId>
-			<artifactId>gs-test</artifactId>
+			<artifactId>gs-test-junit4</artifactId>
 			<scope>test</scope>
 		</dependency>
 		

--- a/examples/lunch-tests/pom.xml
+++ b/examples/lunch-tests/pom.xml
@@ -21,7 +21,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.avanza.gs</groupId>
-			<artifactId>gs-test</artifactId>
+			<artifactId>gs-test-junit4</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
 		<netty.version>4.1.69.Final</netty.version>
 		<mimer-config.version>0.0.8</mimer-config.version>
 		<hystrix-multiconfig.version>0.0.3</hystrix-multiconfig.version>
-		<gs-test.version>2.0.1</gs-test.version>
+		<gs-test.version>2.1.0</gs-test.version>
 
 		<!-- Plugins -->
 		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
@@ -309,7 +309,7 @@
 			</dependency>
 			<dependency>
 				<groupId>com.avanza.gs</groupId>
-				<artifactId>gs-test</artifactId>
+				<artifactId>gs-test-junit4</artifactId>
 				<version>${gs-test.version}</version>
 			</dependency>
 			<dependency>

--- a/tutorial/trading-api-parent/trading-pu/pom.xml
+++ b/tutorial/trading-api-parent/trading-pu/pom.xml
@@ -45,7 +45,7 @@
   	</dependency>
   	<dependency>
 		<groupId>com.avanza.gs</groupId>
-		<artifactId>gs-test</artifactId>
+		<artifactId>gs-test-junit4</artifactId>
   		<scope>test</scope>
   	</dependency>
   </dependencies>


### PR DESCRIPTION
Use updated `gs-test` module that uses unicast instead of multicast.

Also, tests are using ZooKeeper based leader selection instead of LUS based.