### PR TITLE
TP-1276: Remove unnecessary dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,9 +143,9 @@
 		<hystrix.version>1.5.18</hystrix.version>
 		<archaius.version>0.4.1</archaius.version>
 		<lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-		<mimer-config.version>0.0.8</mimer-config.version>
+		<mimer-config.version>0.0.9</mimer-config.version>
 		<hystrix-multiconfig.version>0.0.3</hystrix-multiconfig.version>
-		<gs-test.version>2.1.3</gs-test.version>
+		<gs-test.version>2.1.6</gs-test.version>
 
 		<!-- Plugins -->
 		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
@@ -213,6 +213,20 @@
 				<groupId>org.gigaspaces</groupId>
 				<artifactId>xap-datagrid</artifactId>
 				<version>${gigaspaces.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.github.oshi</groupId>
+						<artifactId>oshi-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.junit.jupiter</groupId>
+						<artifactId>*</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.xerial</groupId>
+						<artifactId>sqlite-jdbc</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.gigaspaces</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 		<lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
 		<mimer-config.version>0.0.9</mimer-config.version>
 		<hystrix-multiconfig.version>0.0.3</hystrix-multiconfig.version>
-		<gs-test.version>2.1.6</gs-test.version>
+		<gs-test.version>2.1.7</gs-test.version>
 
 		<!-- Plugins -->
 		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>


### PR DESCRIPTION
This removes transitive dependencies on:
* `org.xerial:sqlite-jdbc` (this is one huge artifact)
* `org.junit.jupiter:junit-jupiter-params` (this should not be a compile-scoped dependency)
* `com.github.oshi:oshi-core` (unused and unnecessary)

Also, bumped dependency versions of `gs-test` and `mimer-config` to latest.